### PR TITLE
Backported patches for 2.0.1

### DIFF
--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -94,7 +94,7 @@ func (i *ImageInspectorOptions) Validate() error {
 	for _, fl := range append(i.DockerCfg.Values, i.PasswordFile) {
 		if len(fl) > 0 {
 			if _, err := os.Stat(fl); os.IsNotExist(err) {
-				return fmt.Errorf("%s does not exists", fl)
+				return fmt.Errorf("%s does not exist", fl)
 			}
 		}
 	}

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -107,7 +107,7 @@ func (i *ImageInspectorOptions) Validate() error {
 			}
 		}
 		if !found {
-			return fmt.Errorf("%s is not one of the available scan-type's which are %v", i.ScanType, ScanOptions)
+			return fmt.Errorf("%s is not one of the available scan-types which are %v", i.ScanType, ScanOptions)
 		}
 	}
 	return nil

--- a/pkg/inspector/image-inspector.go
+++ b/pkg/inspector/image-inspector.go
@@ -351,7 +351,7 @@ func appendDockerCfgConfigs(dockercfg string, cfgs *docker.AuthConfigurations) e
 
 func (i *defaultImageInspector) getAuthConfigs() (*docker.AuthConfigurations, error) {
 	imagePullAuths := &docker.AuthConfigurations{
-		map[string]docker.AuthConfiguration{}}
+		map[string]docker.AuthConfiguration{"": {}}}
 	if len(i.opts.DockerCfg.Values) > 0 {
 		for _, dcfgFile := range i.opts.DockerCfg.Values {
 			if err := appendDockerCfgConfigs(dcfgFile, imagePullAuths); err != nil {

--- a/pkg/inspector/image-inspector.go
+++ b/pkg/inspector/image-inspector.go
@@ -336,6 +336,7 @@ func appendDockerCfgConfigs(dockercfg string, cfgs *docker.AuthConfigurations) e
 	if err != nil {
 		return fmt.Errorf("Unable to open docker config file: %v\n", err)
 	}
+	defer reader.Close()
 	if imagePullAuths, err = docker.NewAuthConfigurations(reader); err != nil {
 		return fmt.Errorf("Unable to parse docker config file: %v\n", err)
 	}
@@ -345,7 +346,6 @@ func appendDockerCfgConfigs(dockercfg string, cfgs *docker.AuthConfigurations) e
 	for name, ac := range imagePullAuths.Configs {
 		cfgs.Configs[fmt.Sprintf("%s/%s", dockercfg, name)] = ac
 	}
-	reader.Close()
 	return nil
 }
 

--- a/pkg/inspector/image-inspector_test.go
+++ b/pkg/inspector/image-inspector_test.go
@@ -66,6 +66,8 @@ func TestScanImage(t *testing.T) {
 }
 
 func TestGetAuthConfigs(t *testing.T) {
+	goodNoAuth := iicmd.NewDefaultImageInspectorOptions()
+
 	goodTwoDockerCfg := iicmd.NewDefaultImageInspectorOptions()
 	goodTwoDockerCfg.DockerCfg.Values = []string{"test/dockercfg1", "test/dockercfg2"}
 
@@ -91,18 +93,19 @@ func TestGetAuthConfigs(t *testing.T) {
 		"two dockercfg, one missing": {opts: badDockerCfgMissing, shouldFail: true},
 		"two dockercfg, one wrong":   {opts: badDockerCfgWrong, shouldFail: true},
 		"two dockercfg, no auth":     {opts: badDockerCfgNoAuth, shouldFail: true},
+		"no auths, default expected": {opts: goodNoAuth, shouldFail: false},
 	}
 
 	for k, v := range tests {
 		ii := &defaultImageInspector{*v.opts, InspectorMetadata{}}
 		auths, err := ii.getAuthConfigs()
 		if !v.shouldFail {
-			var expectedLength int = len(v.opts.DockerCfg.Values)
+			var expectedLength int = len(v.opts.DockerCfg.Values) + 1
 			if len(v.opts.Username) > 0 {
-				expectedLength = expectedLength + 1
+				expectedLength = 1
 			}
 			if err != nil {
-				t.Errorf("%s expected to validate but received %v", k, err)
+				t.Errorf("%s expected to succeed but received %v", k, err)
 			}
 			var authsLen int = 0
 			if auths != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,15 @@
+package util
+
+func StrOrDefault(s string, d string) string {
+	if len(s) == 0 { // s || d
+		return d
+	}
+	return s
+}
+
+func Min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestStrOrDefault(t *testing.T) {
+	if StrOrDefault("", "Default") != "Default" {
+		t.Errorf("strOrDefault should return the default string if the first one is empty")
+	}
+	if StrOrDefault("TestString", "Default") != "TestString" {
+		t.Errorf("strOrDefault should return the first string if it is not empty")
+	}
+}
+
+func TestMin(t *testing.T) {
+	if Min(2, 3) != 2 {
+		t.Errorf("should return 2")
+	}
+	if Min(3, 2) != 2 {
+		t.Errorf("should return 2")
+	}
+}


### PR DESCRIPTION
These are the candidate patches for the `release-2.0.z` branch to release 2.0.1.

@enoodle @pweil- make sure we're not missing something and we're not introducing regressions. Thanks.