### PR TITLE
openscap: ship with static cve for network-isolated clusters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,8 @@ EXPOSE 8080
 
 WORKDIR /var/lib/image-inspector
 
+RUN mkdir cve_feeds && \
+    wget --no-verbose -P cve_feeds/ \
+    https://www.redhat.com/security/data/metrics/ds/com.redhat.rhsa-RHEL{5,6,7}.ds.xml.bz2
+
 ENTRYPOINT ["/usr/bin/image-inspector"]


### PR DESCRIPTION
Proposed Fix for #18 

Added downloading of CVE files while building the image (in `Dockerfile`).
OpenSCAP will now try to access them if it couldn't download ones from the normal channel.

cc @simon3z @mpreisler
