### PR TITLE
Adding CVEURLPath argument for alternative CVE source

### DIFF
--- a/cmd/image-inspector.go
+++ b/cmd/image-inspector.go
@@ -23,6 +23,7 @@ func main() {
 	flag.StringVar(&inspectorOptions.ScanType, "scan-type", inspectorOptions.ScanType, fmt.Sprintf("The type of the scan to be done on the inspected image. Available scan types are: %v", iicmd.ScanOptions))
 	flag.StringVar(&inspectorOptions.ScanResultsDir, "scan-results-dir", inspectorOptions.ScanResultsDir, "The directory that will contain the results of the scan")
 	flag.BoolVar(&inspectorOptions.OpenScapHTML, "openscap-html-report", inspectorOptions.OpenScapHTML, "Generate an OpenScap HTML report in addition to the ARF formatted report")
+	flag.StringVar(&inspectorOptions.CVEUrlPath, "cve-url", inspectorOptions.CVEUrlPath, "An alternative URL source for CVE files")
 
 	flag.Parse()
 

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	oscapscanner "github.com/openshift/image-inspector/pkg/openscap"
 	"os"
 )
 
@@ -49,6 +50,8 @@ type ImageInspectorOptions struct {
 	ScanResultsDir string
 	// OpenScapHTML controls whether or not to generate an HTML report
 	OpenScapHTML bool
+	// CVEUrlPath An alternative source for the cve files
+	CVEUrlPath string
 }
 
 // NewDefaultImageInspectorOptions provides a new ImageInspectorOptions with default values.
@@ -65,6 +68,7 @@ func NewDefaultImageInspectorOptions() *ImageInspectorOptions {
 		ScanType:       "",
 		ScanResultsDir: "",
 		OpenScapHTML:   false,
+		CVEUrlPath:     oscapscanner.CVEUrl,
 	}
 }
 

--- a/pkg/inspector/image-inspector.go
+++ b/pkg/inspector/image-inspector.go
@@ -113,7 +113,7 @@ func (i *defaultImageInspector) Inspect() error {
 		if i.opts.ScanResultsDir, err = createOutputDir(i.opts.ScanResultsDir, "image-inspector-scan-results-"); err != nil {
 			return err
 		}
-		scanner := openscap.NewDefaultScanner(OSCAP_CVE_DIR, i.opts.ScanResultsDir, i.opts.OpenScapHTML)
+		scanner := openscap.NewDefaultScanner(OSCAP_CVE_DIR, i.opts.ScanResultsDir, i.opts.CVEUrlPath, i.opts.OpenScapHTML)
 		scanReport, htmlScanReport, err = i.scanImage(scanner)
 		if err != nil {
 			i.meta.OpenSCAP.SetError(err)


### PR DESCRIPTION
A proposed fix for #18 

Added a new argument to image-inspector (and to OSCAPScanner) to get an alternative CVE source from the user.
