### PR TITLE
HTML Reporting for OpenSCAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ Image Inspector can extract docker images to a target directory and
     ...
 
 Image Inspector can inspect images using OpenSCAP and serve the scan result.
-The OpenSCAP scan report will be served on <serve_path>/api/v1/openscap and 
+The OpenSCAP scan report will be served on <serve_path>/api/v1/openscap and
 the status of the scan will be available on <serve_path>/api/v1/metadata in
-the OpenSCAP section.
+the OpenSCAP section.  An HTML OpenSCAP scan report will be served on
+<serve_path>/api/v1/openscap-report if the --html option is used.
 
     $ sudo ./image-inspector --image=fedora:22 --path=/tmp/image-content --scan-type=openscap
 			--serve 0.0.0.0:8080 --chroot

--- a/cmd/image-inspector.go
+++ b/cmd/image-inspector.go
@@ -22,6 +22,7 @@ func main() {
 	flag.StringVar(&inspectorOptions.PasswordFile, "password-file", inspectorOptions.PasswordFile, "Location of a file that contains the password for authentication with the docker registry")
 	flag.StringVar(&inspectorOptions.ScanType, "scan-type", inspectorOptions.ScanType, fmt.Sprintf("The type of the scan to be done on the inspected image. Available scan types are: %v", iicmd.ScanOptions))
 	flag.StringVar(&inspectorOptions.ScanResultsDir, "scan-results-dir", inspectorOptions.ScanResultsDir, "The directory that will contain the results of the scan")
+	flag.BoolVar(&inspectorOptions.OpenScapHTML, "openscap-html-report", inspectorOptions.OpenScapHTML, "Generate an OpenScap HTML report in addition to the ARF formatted report")
 
 	flag.Parse()
 

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -47,6 +47,8 @@ type ImageInspectorOptions struct {
 	ScanType string
 	// ScanResultsDir is the directory that will contain the results of the scan
 	ScanResultsDir string
+	// OpenScapHTML controls whether or not to generate an HTML report
+	OpenScapHTML bool
 }
 
 // NewDefaultImageInspectorOptions provides a new ImageInspectorOptions with default values.
@@ -62,6 +64,7 @@ func NewDefaultImageInspectorOptions() *ImageInspectorOptions {
 		PasswordFile:   "",
 		ScanType:       "",
 		ScanResultsDir: "",
+		OpenScapHTML:   false,
 	}
 }
 
@@ -91,6 +94,9 @@ func (i *ImageInspectorOptions) Validate() error {
 			return fmt.Errorf("%s is not a directory", i.ScanResultsDir)
 		}
 	}
+	if i.OpenScapHTML && (len(i.ScanType) == 0 || i.ScanType != "openscap") {
+		return fmt.Errorf("OpenScapHtml can be used only when specifying scan-type as \"openscap\"")
+	}
 	for _, fl := range append(i.DockerCfg.Values, i.PasswordFile) {
 		if len(fl) > 0 {
 			if _, err := os.Stat(fl); os.IsNotExist(err) {
@@ -109,6 +115,7 @@ func (i *ImageInspectorOptions) Validate() error {
 		if !found {
 			return fmt.Errorf("%s is not one of the available scan-types which are %v", i.ScanType, ScanOptions)
 		}
+
 	}
 	return nil
 }

--- a/pkg/cmd/types_test.go
+++ b/pkg/cmd/types_test.go
@@ -39,6 +39,7 @@ func TestValidate(t *testing.T) {
 	goodScanOptions.Image = "image"
 	goodScanOptions.ScanType = "openscap"
 	goodScanOptions.ScanResultsDir = "."
+	goodScanOptions.Html = true
 
 	notADirResScan := NewDefaultImageInspectorOptions()
 	notADirResScan.Image = "image"
@@ -54,22 +55,33 @@ func TestValidate(t *testing.T) {
 	noSuchFileDockercfg.Image = "image"
 	noSuchFileDockercfg.DockerCfg.Set("nosuchfile")
 
+	badScanOptionsHTMLnoScan := NewDefaultImageInspectorOptions()
+	badScanOptionsHTMLnoScan.Image = "image"
+	badScanOptionsHTMLnoScan.Html = true
+
+	badScanOptionsHTMLWrongScan := NewDefaultImageInspectorOptions()
+	badScanOptionsHTMLWrongScan.Image = "image"
+	badScanOptionsHTMLWrongScan.Html = true
+	badScanOptionsHTMLWrongScan.ScanType = "nosuchscantype"
+
 	tests := map[string]struct {
 		inspector      *ImageInspectorOptions
 		shouldValidate bool
 	}{
-		"no uri":                        {inspector: noURI, shouldValidate: false},
-		"no image":                      {inspector: NewDefaultImageInspectorOptions(), shouldValidate: false},
-		"docker config and username":    {inspector: dockerCfgAndUsername, shouldValidate: false},
-		"username and no password file": {inspector: usernameNoPasswordFile, shouldValidate: false},
-		"no serve and chroot":           {inspector: noServeAndChroot, shouldValidate: false},
-		"good config with username":     {inspector: goodConfigUsername, shouldValidate: true},
-		"good config with docker cfg":   {inspector: goodConfigWithDockerCfg, shouldValidate: true},
-		"no scan-type with scan-dir":    {inspector: noScanTypeAndDir, shouldValidate: false},
-		"no such file dockercfg":        {inspector: noSuchFileDockercfg, shouldValidate: false},
-		"no such scan type available":   {inspector: noSuchScanType, shouldValidate: false},
-		"file exists and is not a dir":  {inspector: notADirResScan, shouldValidate: false},
-		"good config with scan options": {inspector: goodScanOptions, shouldValidate: true},
+		"no uri":                              {inspector: noURI, shouldValidate: false},
+		"no image":                            {inspector: NewDefaultImageInspectorOptions(), shouldValidate: false},
+		"docker config and username":          {inspector: dockerCfgAndUsername, shouldValidate: false},
+		"username and no password file":       {inspector: usernameNoPasswordFile, shouldValidate: false},
+		"no serve and chroot":                 {inspector: noServeAndChroot, shouldValidate: false},
+		"good config with username":           {inspector: goodConfigUsername, shouldValidate: true},
+		"good config with docker cfg":         {inspector: goodConfigWithDockerCfg, shouldValidate: true},
+		"no scan-type with scan-dir":          {inspector: noScanTypeAndDir, shouldValidate: false},
+		"no such file dockercfg":              {inspector: noSuchFileDockercfg, shouldValidate: false},
+		"no such scan type available":         {inspector: noSuchScanType, shouldValidate: false},
+		"file exists and is not a dir":        {inspector: notADirResScan, shouldValidate: false},
+		"good config with scan options":       {inspector: goodScanOptions, shouldValidate: true},
+		"bad config with html and no scan":    {inspector: badScanOptionsHTMLnoScan, shouldValidate: false},
+		"bad config with html and wrong scan": {inspector: badScanOptionsHTMLWrongScan, shouldValidate: false},
 	}
 
 	for k, v := range tests {

--- a/pkg/openscap/types.go
+++ b/pkg/openscap/types.go
@@ -12,4 +12,6 @@ type Scanner interface {
 	ScannerName() string
 	// ResultFileName returns the name of the results file
 	ResultsFileName() string
+	// HtmlResultFileName returns the name of the results file
+	HTMLResultsFileName() string
 }


### PR DESCRIPTION
I added an option to display an HTML report for an OpenSCAP scan.  It is served at <serve_path>/api/v1/openscap-report.  

I thought this would be a convenient option.