### PR TITLE
Change to DownloadFromContainer

### DIFF
--- a/pkg/inspector/image-inspector.go
+++ b/pkg/inspector/image-inspector.go
@@ -323,11 +323,12 @@ func (i *defaultImageInspector) createAndExtractImage(client *docker.Client, con
 	// the reader to read.
 	errorChannel := make(chan error)
 	go func() {
-		errorChannel <- client.CopyFromContainer(docker.CopyFromContainerOptions{
-			Container:    container.ID,
-			OutputStream: writer,
-			Resource:     "/",
-		})
+		errorChannel <- client.DownloadFromContainer(
+			container.ID,
+			docker.DownloadFromContainerOptions{
+				OutputStream: writer,
+				Path:         "/",
+			})
 	}()
 
 	// block on handling the reads here so we ensure both the write and the reader are finished

--- a/pkg/inspector/image-inspector.go
+++ b/pkg/inspector/image-inspector.go
@@ -335,7 +335,7 @@ func (i *defaultImageInspector) createAndExtractImage(client *docker.Client, con
 	// (read waits until an EOF or error occurs).
 	handleTarStream(reader, i.opts.DstPath)
 
-	// capture any error from the copy, ensures both the handleTarStream and CopyFromContainer
+	// capture any error from the copy, ensures both the handleTarStream and DownloadFromContainer
 	// are done.
 	err = <-errorChannel
 	if err != nil {


### PR DESCRIPTION
This function uses the containers/<ID>/archive API instead of the now deprecated containers/<ID>/copy (used by the CopyFromContainer function).
