### PR TITLE
add authorization check to webdav server 

### DIFF
--- a/cmd/image-inspector.go
+++ b/cmd/image-inspector.go
@@ -3,7 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
+	"os"
 
 	iiapi "github.com/openshift/image-inspector/pkg/api"
 	iicmd "github.com/openshift/image-inspector/pkg/cmd"
@@ -27,8 +29,19 @@ func main() {
 	flag.StringVar(&inspectorOptions.CVEUrlPath, "cve-url", inspectorOptions.CVEUrlPath, "An alternative URL source for CVE files")
 	flag.StringVar(&inspectorOptions.PostResultURL, "post-results-url", inspectorOptions.PostResultURL, "After scan finish, HTTP POST the results to this URL")
 	flag.StringVar(&inspectorOptions.PostResultTokenFile, "post-results-token-file", inspectorOptions.PostResultTokenFile, "If specified, content of it will be added to the POST result URL (?token=....)")
+	flag.StringVar(&inspectorOptions.AuthTokenFile, "webdav-token-file", inspectorOptions.AuthTokenFile, "If specified, token used to authenticate to Image Inspector will be read from this file")
 
 	flag.Parse()
+
+	if inspectorOptions.AuthTokenFile != "" {
+		authToken, err := ioutil.ReadFile(inspectorOptions.AuthTokenFile)
+		if err != nil {
+			log.Fatalf("error reading auth token file: %v", err)
+		}
+		inspectorOptions.AuthToken = string(authToken)
+	} else {
+		inspectorOptions.AuthToken = os.Getenv("INSPECTOR_AUTH_TOKEN")
+	}
 
 	if err := inspectorOptions.Validate(); err != nil {
 		log.Fatal(err)

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -62,6 +62,13 @@ type ImageInspectorOptions struct {
 	// PostResultTokenFile if specified the content of the file will be added as a token to
 	// the result POST URL (eg. http://foo/?token=CONTENT.
 	PostResultTokenFile string
+	// AuthToken is a Shared Secret used to validate HTTP Requests.
+	// AuthToken can be set through AuthTokenFile or ENV
+	AuthToken string
+
+	// AuthTokenFile is the path to a file containing the AuthToken
+	// If it is not provided, the AuthToken will be read from the ENV
+	AuthTokenFile string
 }
 
 // NewDefaultImageInspectorOptions provides a new ImageInspectorOptions with default values.

--- a/pkg/imageserver/types.go
+++ b/pkg/imageserver/types.go
@@ -38,4 +38,7 @@ type ImageServerOptions struct {
 	HTMLScanReport bool
 	// HTMLScanReportURL url for the scan html report
 	HTMLScanReportURL string
+	// AuthToken is a Shared Secret used to validate HTTP Requests.
+	// AuthToken is set through ENV rather than passed as a parameter
+	AuthToken string
 }

--- a/pkg/inspector/image-inspector.go
+++ b/pkg/inspector/image-inspector.go
@@ -94,6 +94,7 @@ func NewDefaultImageInspector(opts iicmd.ImageInspectorOptions) ImageInspector {
 			ScanReportURL:     OPENSCAP_URL_PATH,
 			HTMLScanReport:    opts.OpenScapHTML,
 			HTMLScanReportURL: OPENSCAP_REPORT_URL_PATH,
+			AuthToken:         opts.AuthToken,
 		}
 		inspector.imageServer = apiserver.NewWebdavImageServer(imageServerOpts, opts.Chroot)
 	}

--- a/pkg/inspector/image-inspector_ginkgo_test.go
+++ b/pkg/inspector/image-inspector_ginkgo_test.go
@@ -1,0 +1,171 @@
+// +build integrationtest
+
+package inspector_test
+
+import (
+	"fmt"
+	"github.com/fsouza/go-dockerclient"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	iicmd "github.com/openshift/image-inspector/pkg/cmd"
+	"github.com/openshift/image-inspector/pkg/imageserver"
+	. "github.com/openshift/image-inspector/pkg/inspector"
+	"net/http"
+	"strings"
+	"time"
+)
+
+var _ = Describe("ImageInspector", func() {
+	var (
+		ii           ImageInspector
+		opts         *iicmd.ImageInspectorOptions
+		serve        = "localhost:8088"
+		validToken   = "w599voG89897rGVDmdp12WA681r9E5948c1CJTPi8g4HGc4NWaz62k6k1K0FMxHW40H8yOO3Hoe"
+		invalidToken = "asdfqwer1234"
+		client       = http.Client{
+			Timeout: time.Minute,
+		}
+	)
+	JustBeforeEach(func() {
+		opts = iicmd.NewDefaultImageInspectorOptions()
+		opts.Serve = serve
+		opts.AuthToken = validToken
+		opts.Image = "fedora:22"
+		opts.ScanType = "openscap"
+
+		ii = NewDefaultImageInspector(*opts)
+
+	})
+	Describe(".Inspect()", func() {
+		//note: no expects in this block
+		//we just begin the http server here
+		It("starts running witouth error", func() {
+			//serving blocks, so it needs to be done in a goroutine
+			go func() {
+				if err := ii.Inspect(); err != nil {
+					panic(err)
+				}
+			}()
+			//allow 3 minutes to pull image
+			if err := waitForImage(opts.URI, opts.Image, time.Minute*3); err != nil {
+				panic(err)
+			}
+			//allow 30s to start serving http
+			if err := waitForServer(opts.Serve, time.Second*30); err != nil {
+				panic(err)
+			}
+		})
+
+		paths := []string{
+			//HEALTHZ_URL_PATH,
+			//API_URL_PREFIX,
+			//METADATA_URL_PATH,
+			//OPENSCAP_URL_PATH,
+			//OPENSCAP_REPORT_URL_PATH,
+			CONTENT_URL_PREFIX,
+		}
+		for _, path := range paths {
+			Context("when user sends HTTP request to "+path, func() {
+				var req *http.Request
+				BeforeEach(func() {
+					var err error
+					req, err = http.NewRequest("GET", "http://"+serve+path, nil)
+					if err != nil {
+						panic(err)
+					}
+				})
+				Context("with incorrect authentication token", func() {
+					BeforeEach(func() {
+						req.Header.Set(imageserver.AUTH_TOKEN_HEADER, invalidToken)
+					})
+					It("should fail with status http.Status BadRequest", func() {
+						res, err := client.Do(req)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(res.StatusCode).To(Equal(http.StatusUnauthorized))
+					})
+				})
+				Context("with correct authentication token", func() {
+					BeforeEach(func() {
+						req.Header.Set(imageserver.AUTH_TOKEN_HEADER, validToken)
+					})
+					It("should authorize the request", func() {
+						res, err := client.Do(req)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(res.StatusCode).NotTo(Equal(http.StatusUnauthorized))
+					})
+				})
+			})
+		}
+	})
+})
+
+func waitForImage(uri, imageName string, timeout time.Duration) error {
+	client, err := docker.NewClient(uri)
+	if err != nil {
+		return err
+	}
+	errchan := make(chan error, 1)
+	pollFunc := func() {
+		images, err := client.ListImages(docker.ListImagesOptions{})
+		if err != nil {
+			errchan <- err
+			return
+		}
+		for _, image := range images {
+			for _, tag := range image.RepoTags {
+				if strings.Contains(tag, imageName) {
+					errchan <- nil
+					return
+				}
+			}
+		}
+	}
+	go func() {
+		for {
+			pollFunc()
+			time.Sleep(time.Second * 5)
+		}
+	}()
+	select {
+	case <-time.After(timeout):
+		return fmt.Errorf("waiting for image timed out after %s", timeout.String())
+	case err := <-errchan:
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+}
+func waitForServer(addr string, timeout time.Duration) error {
+	errchan := make(chan error, 1)
+	pollFunc := func() {
+		req, err := http.NewRequest("GET", "http://"+addr+"/", nil)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := http.DefaultClient.Do(req); err != nil {
+			if strings.Contains(err.Error(), "connection refused") {
+				return //still waiting
+			}
+			errchan <- err
+			return
+		}
+		errchan <- nil
+		return
+	}
+	go func() {
+		for {
+			pollFunc()
+			time.Sleep(time.Second * 5)
+		}
+	}()
+	select {
+	case <-time.After(timeout):
+		return fmt.Errorf("waiting for sever timed out after %s", timeout.String())
+	case err := <-errchan:
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+}

--- a/pkg/inspector/inspector_suite_test.go
+++ b/pkg/inspector/inspector_suite_test.go
@@ -1,0 +1,15 @@
+// +build integrationtest
+
+package inspector_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestInspector(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Inspector Suite")
+}


### PR DESCRIPTION
this PR adds func checkAuth to image-inspector.go
checkAuth looks for an OAuth token on a request before calling the next http handler
currently it's only applied to the WebDAV content server

simple unit test added using ginkgo