### PR TITLE
Send "ServeImage" the location of the image contents

### DIFF
--- a/pkg/imageserver/types.go
+++ b/pkg/imageserver/types.go
@@ -7,8 +7,13 @@ import (
 // ImageServer abstracts the serving of image information.
 type ImageServer interface {
 	// ServeImage Serves the image
+	// ImageServeURL is the location that the image is being served from.
 	// TODO: Move the scanReport and htmlScanReport into OpenSCAP results?
-	ServeImage(meta *iiapi.InspectorMetadata, results iiapi.ScanResult, scanReport []byte, htmlScanReport []byte) error
+	ServeImage(meta *iiapi.InspectorMetadata,
+		ImageServeURL string,
+		results iiapi.ScanResult,
+		scanReport []byte,
+		htmlScanReport []byte) error
 }
 
 // ImageServerOptions is used to configure an image server.
@@ -27,10 +32,6 @@ type ImageServerOptions struct {
 	MetadataURL string
 	// ContentURL is the relative url of the content.  ex /api/v1/content/
 	ContentURL string
-	// ImageServeURL is the location that the image is being served from.
-	// NOTE: if the image server supports a chroot the server implementation will perform
-	// the chroot based on this URL.
-	ImageServeURL string
 	// ScanType is the type of the scan that was done on the inspected image
 	ScanType string
 	// ScanReportURL is the url to publish the scan report

--- a/pkg/imageserver/webdav.go
+++ b/pkg/imageserver/webdav.go
@@ -43,15 +43,16 @@ func NewWebdavImageServer(opts ImageServerOptions, chroot bool) ImageServer {
 
 // ServeImage Serves the image.
 func (s *webdavImageServer) ServeImage(meta *iiapi.InspectorMetadata,
+	ImageServeURL string,
 	results iiapi.ScanResult,
 	scanReport []byte,
 	htmlScanReport []byte,
 ) error {
 
-	servePath := s.opts.ImageServeURL
+	servePath := ImageServeURL
 	if s.chroot {
-		if err := syscall.Chroot(s.opts.ImageServeURL); err != nil {
-			return fmt.Errorf("Unable to chroot into %s: %v\n", s.opts.ImageServeURL, err)
+		if err := syscall.Chroot(ImageServeURL); err != nil {
+			return fmt.Errorf("Unable to chroot into %s: %v\n", ImageServeURL, err)
 		}
 		servePath = CHROOT_SERVE_PATH
 	} else {
@@ -60,7 +61,7 @@ func (s *webdavImageServer) ServeImage(meta *iiapi.InspectorMetadata,
 		log.Printf("information of the hosting system.")
 	}
 
-	log.Printf("Serving image content %s on webdav://%s%s", s.opts.ImageServeURL, s.opts.ServePath, s.opts.ContentURL)
+	log.Printf("Serving image content %s on webdav://%s%s", ImageServeURL, s.opts.ServePath, s.opts.ContentURL)
 
 	http.Handle(s.opts.HealthzURL, s.checkAuth(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("ok\n"))

--- a/pkg/inspector/image-inspector.go
+++ b/pkg/inspector/image-inspector.go
@@ -92,7 +92,6 @@ func NewDefaultImageInspector(opts iicmd.ImageInspectorOptions) ImageInspector {
 			APIVersions:       iiapi.APIVersions{Versions: []string{VERSION_TAG}},
 			MetadataURL:       METADATA_URL_PATH,
 			ContentURL:        CONTENT_URL_PREFIX,
-			ImageServeURL:     opts.DstPath,
 			ScanType:          opts.ScanType,
 			ScanReportURL:     OPENSCAP_URL_PATH,
 			HTMLScanReport:    opts.OpenScapHTML,
@@ -200,7 +199,7 @@ func (i *defaultImageInspector) Inspect() error {
 	}
 
 	if i.imageServer != nil {
-		return i.imageServer.ServeImage(&i.meta, scanResults, scanReport, htmlScanReport)
+		return i.imageServer.ServeImage(&i.meta, i.opts.DstPath, scanResults, scanReport, htmlScanReport)
 	}
 
 	return nil


### PR DESCRIPTION
Some times the value of DstPath is updated during the
inspection of the image. This will ensure it will be updated for the server.