### PR TITLE
WIP: Scan running container

### DIFF
--- a/cmd/image-inspector.go
+++ b/cmd/image-inspector.go
@@ -15,6 +15,7 @@ func main() {
 
 	flag.StringVar(&inspectorOptions.URI, "docker", inspectorOptions.URI, "Daemon socket to connect to")
 	flag.StringVar(&inspectorOptions.Image, "image", inspectorOptions.Image, "Docker image to inspect")
+	flag.StringVar(&inspectorOptions.ContainerId, "container", inspectorOptions.ContainerId, "Running docker container id to inspect")
 	flag.StringVar(&inspectorOptions.DstPath, "path", inspectorOptions.DstPath, "Destination path for the image files")
 	flag.StringVar(&inspectorOptions.Serve, "serve", inspectorOptions.Serve, "Host and port where to serve the image with webdav")
 	flag.BoolVar(&inspectorOptions.Chroot, "chroot", inspectorOptions.Chroot, "Change root when serving the image with webdav")

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -27,7 +27,7 @@ func (osm *OpenSCAPMetadata) SetError(err error) {
 }
 
 var (
-	ScanOptions = []string{"openscap"}
+	ScanOptions = []string{"openscap", "fake-scan"}
 )
 
 // InspectorMetadata is the metadata type with information about image-inspector's operation

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -31,6 +31,8 @@ type ImageInspectorOptions struct {
 	URI string
 	// Image contains the docker image to inspect.
 	Image string
+	// Container id is the pid of a running container to be scanned
+	ContainerId string
 	// DstPath is the destination path for image files.
 	DstPath string
 	// Serve holds the host and port for where to serve the image with webdav.
@@ -77,8 +79,8 @@ func (i *ImageInspectorOptions) Validate() error {
 	if len(i.URI) == 0 {
 		return fmt.Errorf("Docker socket connection must be specified")
 	}
-	if len(i.Image) == 0 {
-		return fmt.Errorf("Docker image to inspect must be specified")
+	if len(i.Image) == 0 && len(i.ContainerId) == 0{
+		return fmt.Errorf("Docker image or container id to inspect must be specified")
 	}
 	if len(i.DockerCfg.Values) > 0 && len(i.Username) > 0 {
 		return fmt.Errorf("Only specify dockercfg file or username/password pair for authentication")

--- a/pkg/inspector/fake_scanner.go
+++ b/pkg/inspector/fake_scanner.go
@@ -1,0 +1,24 @@
+package inspector
+
+import (
+	"fmt"
+
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+// todo move openscap scanner interface to generic location
+type FakeScanner struct{}
+
+func (s *FakeScanner) Scan(dstPath string, image *docker.Image) error{
+	fmt.Printf("scanning contents at %s", dstPath)
+	return nil
+}
+func (s *FakeScanner) ScannerName() string {
+	return "Fake Scanner"
+}
+func (s *FakeScanner) ResultsFileName() string {
+	return "results file name"
+}
+func (s *FakeScanner) HTMLResultsFileName() string {
+	return "html results file name"
+}


### PR DESCRIPTION
@simon3z @enoodle @mfojtik @legionus 

Playing around with support for scanning a running container.  Do you think a symlink to proc is a reasonable approach to this?  Any other ideas in this area?

This assumes you could schedule the II pod on the node where the container is running (perhaps as a CronJob that wraps it and feeds the docker sha).