### PR TITLE
[2.1] parse dockers daemon response for errors

### DIFF
--- a/pkg/inspector/image-inspector.go
+++ b/pkg/inspector/image-inspector.go
@@ -200,30 +200,47 @@ func aggregateBytesAndReport(bytesChan chan int) {
 	}
 }
 
-// decodeDockerPullMessages will parse the docker pull messages received
-// from reader and will push the difference of bytes downloaded to
-// bytesChan. After reader is closed it will close bytesChan and exit.
-func decodeDockerPullMessages(bytesChan chan int, reader io.Reader) {
+// decodeDockerResponse will parse the docker pull messages received
+// from reader. It will start aggregateBytesAndReport with bytesChan
+// and will push the difference of bytes downloaded to bytesChan.
+// Errors encountered during parsing are reported to parsedErrors channel.
+// After reader is closed it will send nil on parsedErrors, close bytesChan and exit.
+func decodeDockerResponse(parsedErrors chan error, reader io.Reader) {
 	type progressDetailType struct {
 		Current, Total int
 	}
 	type pullMessage struct {
 		Status, Id     string
 		ProgressDetail progressDetailType
+		Error          string
 	}
+	bytesChan := make(chan int, 100)
 	defer func() { close(bytesChan) }()           // Closing the channel to end the other routine
 	layersBytesDownloaded := make(map[string]int) // bytes downloaded per layer
 	dec := json.NewDecoder(reader)                // decoder for the json messages
+
+	var startedDownloading = false
 	for {
 		var v pullMessage
 		if err := dec.Decode(&v); err != nil {
-			if err != io.ErrClosedPipe {
+			if err != io.ErrClosedPipe && err != io.EOF {
 				log.Printf("Error decoding json: %v", err)
+				parsedErrors <- fmt.Errorf("Error decoding json: %v", err)
+			} else {
+				parsedErrors <- nil
 			}
 			break
 		}
 		// decoding
+		if v.Error != "" {
+			parsedErrors <- fmt.Errorf(v.Error)
+			break
+		}
 		if v.Status == "Downloading" {
+			if !startedDownloading {
+				go aggregateBytesAndReport(bytesChan)
+				startedDownloading = true
+			}
 			bytes := v.ProgressDetail.Current
 			last, existed := layersBytesDownloaded[v.Id]
 			if !existed {
@@ -247,27 +264,33 @@ func (i *defaultImageInspector) pullImage(client *docker.Client) error {
 		return authCfgErr
 	}
 
-	reader, writer := io.Pipe()
-	// handle closing the reader/writer in the method that creates them
-	defer writer.Close()
-	defer reader.Close()
-	imagePullOption := docker.PullImageOptions{
-		Repository:    i.opts.Image,
-		OutputStream:  writer,
-		RawJSONStream: true,
-	}
-
-	bytesChan := make(chan int)
-	go aggregateBytesAndReport(bytesChan)
-	go decodeDockerPullMessages(bytesChan, reader)
-
 	// Try all the possible auth's from the config file
 	var authErr error
 	for name, auth := range imagePullAuths.Configs {
-		if authErr = client.PullImage(imagePullOption, auth); authErr == nil {
+		parsedErrors := make(chan error, 100)
+		defer func() { close(parsedErrors) }()
+
+		go func() {
+			reader, writer := io.Pipe()
+			defer writer.Close()
+			defer reader.Close()
+			imagePullOption := docker.PullImageOptions{
+				Repository:    i.opts.Image,
+				OutputStream:  writer,
+				RawJSONStream: true,
+			}
+			go decodeDockerResponse(parsedErrors, reader)
+
+			if err := client.PullImage(imagePullOption, auth); err != nil {
+				parsedErrors <- err
+			}
+		}()
+
+		if parsedError := <-parsedErrors; parsedError != nil {
+			log.Printf("Authentication with %s failed: %v", name, parsedError)
+		} else {
 			return nil
 		}
-		log.Printf("Authentication with %s failed: %v", name, authErr)
 	}
 	return fmt.Errorf("Unable to pull docker image: %v\n", authErr)
 }

--- a/pkg/inspector/image-inspector_test.go
+++ b/pkg/inspector/image-inspector_test.go
@@ -2,6 +2,7 @@ package inspector
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -160,6 +161,53 @@ func TestGetAuthConfigs(t *testing.T) {
 		} else {
 			if err == nil {
 				t.Errorf("%s should have failed be it didn't", k)
+			}
+		}
+	}
+}
+
+func Test_decodeDockerResponse(t *testing.T) {
+	no_error_input := "{\"Status\": \"fine\"}"
+	one_error := "{\"Status\": \"fine\"}{\"Error\": \"Oops\"}{\"Status\": \"fine\"}"
+	decode_error := "{}{}what"
+	decode_error_message := "Error decoding json: invalid character 'w' looking for beginning of value"
+	tests := map[string]struct {
+		readerInput    string
+		expectedErrors bool
+		errorMessage   string
+	}{
+		"no error":      {readerInput: no_error_input, expectedErrors: false},
+		"error":         {readerInput: one_error, expectedErrors: true, errorMessage: "Oops"},
+		"decode errror": {readerInput: decode_error, expectedErrors: true, errorMessage: decode_error_message},
+	}
+
+	for test_name, test_params := range tests {
+		parsedErrors := make(chan error, 100)
+		defer func() { close(parsedErrors) }()
+
+		go func() {
+			reader, writer := io.Pipe()
+			// handle closing the reader/writer in the method that creates them
+			defer reader.Close()
+			defer writer.Close()
+			go decodeDockerResponse(parsedErrors, reader)
+			writer.Write([]byte(test_params.readerInput))
+		}()
+
+		select {
+		case decodedErrors := <-parsedErrors:
+			if decodedErrors == nil && test_params.expectedErrors {
+				t.Errorf("Expected to parse an error, but non was parsed in test %s", test_name)
+			}
+			if decodedErrors != nil {
+				if !test_params.expectedErrors {
+					t.Errorf("Expected not to get errors in test %s but got: %v", test_name, decodedErrors)
+				} else {
+					if decodedErrors.Error() != test_params.errorMessage {
+						t.Errorf("Expected error message is different than expected in test %s. Expected %v received %v",
+							test_name, test_params.errorMessage, decodedErrors.Error())
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This will parse the response for errors and will attempt the next authentication configuration if an error is found.

To easily communicate the errors found a new channel is created and the go routines that handles the parsing and reporting will be started and destroyed for each authentication attempt.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1449742
Original Master PR: #42 