### PR TITLE
build: add multi-stage build support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 .git
-image-inspector
 README.md
 *.a

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM centos:7
 MAINTAINER      Federico Simoncelli <fsimonce@redhat.com>
 
-RUN yum update -y && \
-    yum install -y golang openscap-scanner git && \
-    yum clean all
+RUN yum update -y --setopt=tsflags=nodocs && \
+    yum install -y --setopt=tsflags=nodocs golang openscap-scanner git && \
+    rm -rf /var/cache/yum
 
 COPY .  /go/src/github.com/openshift/image-inspector
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,8 @@
+FROM golang:1.7
+MAINTAINER Federico Simoncelli <fsimonce@redhat.com>
+
+COPY .  /go/src/github.com/openshift/image-inspector
+
+RUN GOBIN=/usr/bin \
+    CGO_ENABLED=0 \
+    go install -a -installsuffix cgo /go/src/github.com/openshift/image-inspector/cmd/image-inspector.go

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,14 @@ all build:
 	hack/build-go.sh
 .PHONY: all build
 
+# Build image.
+#
+# Example:
+#   make image
+image:
+	hack/build-image.sh
+.PHONY: image
+
 # Remove all build artifacts.
 #
 # Example:

--- a/hack/build-image.sh
+++ b/hack/build-image.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+IMAGENAME=${IMAGENAME:-docker.io/openshift/image-inspector}
+EXTRACTNAME=${EXTRACTNAME:-image-inspector-extract}
+BINNAME=image-inspector
+
+rm -f ${BINNAME}
+
+echo Building ${IMAGENAME}:build
+
+docker build --no-cache --pull -t ${IMAGENAME}:build . -f Dockerfile.build
+
+docker create --name ${EXTRACTNAME} ${IMAGENAME}:build
+docker cp ${EXTRACTNAME}:/usr/bin/${BINNAME} ${BINNAME}
+docker rm -f ${EXTRACTNAME}
+
+echo Building ${IMAGENAME}:latest
+
+docker build --no-cache --pull -t ${IMAGENAME}:latest .


### PR DESCRIPTION
Adding the support for multi-stage builds we save ~92MB in image size (97MB vs 189MB).

At the moment we lose the automated builds on dockerhub (which I wasn't using anyway) until the official multi-stage build will be available (docker 1.17 IIRC).

cc @pweil- @ilackarms @mfojtik 