### PR TITLE
Openscap - Only parse reports when scan was successful

### DIFF
--- a/pkg/inspector/image-inspector.go
+++ b/pkg/inspector/image-inspector.go
@@ -156,13 +156,11 @@ func (i *defaultImageInspector) Inspect() error {
 			log.Printf("DEBUG: Unable to scan image %q with OpenSCAP: %v", i.opts.Image, err)
 		} else {
 			i.meta.OpenSCAP.Status = iiapi.StatusSuccess
+			report := reportObj.(openscap.OpenSCAPReport)
+			scanReport = report.ArfBytes
+			htmlScanReport = report.HTMLBytes
+			scanResults.Results = append(scanResults.Results, results...)
 		}
-
-		report := reportObj.(openscap.OpenSCAPReport)
-		scanReport = report.ArfBytes
-		htmlScanReport = report.HTMLBytes
-
-		scanResults.Results = append(scanResults.Results, results...)
 
 	case "clamav":
 		scanner = clamav.NewScanner(i.opts.ClamSocket)


### PR DESCRIPTION
This fixes ~two~ one minor problems that can cause image-inspector to crush


1. If the scan fails then the results will still be sent to be parsed and this will cause a panic that will crush the software. Moved the parsing to only happen when the scan was successful.


2. ~When given the argument is appended with the name of the expected CVE file which is not the intent of this argument.~ I remembered that for this parameter that it is expected to be a path to be appended with "com.redhat.rhsa-RHEL7.ds.xml.bz2". (7 could be replaced with the RHEL version of the scanned image). I now feel that this will be a bit less convenient when providing entirely different cve files with custom checks. I just wanted to fix small bugs here so I removed this.