### PR TITLE
Add integration tests to Travis CI jobs

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+function build_container(){
+    docker build -t travis/image-inspector-base .
+    cat > Dockerfile.travis <<EOF
+FROM travis/image-inspector-base
+RUN yum install -y \
+    git \
+    which \
+    make
+RUN yum remove -y golang
+RUN curl -O https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.8.3.linux-amd64.tar.gz && \
+    rm -f  go1.8.3.linux-amd64.tar.gz
+ENV PATH=${PATH}:/usr/local/go/bin
+ENV GOPATH=/go
+COPY . /go/src/github.com/openshift/image-inspector
+WORKDIR /go/src/github.com/openshift/image-inspector
+RUN make install-travis
+ENTRYPOINT make
+EOF
+    docker build -t travis/image-inspector -f Dockerfile.travis .
+}
+
+function run_tests(){
+  docker run --rm --privileged \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          --entrypoint make \
+          travis/image-inspector verify test-unit
+}
+
+function usage() {
+    echo "usage: .travis.sh build|run"
+    exit 1
+}
+
+case "$1" in
+    build)
+        build_container
+        ;;
+    run)
+        run_tests
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/.travis.sh
+++ b/.travis.sh
@@ -2,23 +2,6 @@
 
 function build_container(){
     docker build -t travis/image-inspector-base .
-    cat > Dockerfile.travis <<EOF
-FROM travis/image-inspector-base
-RUN yum install -y \
-    git \
-    which \
-    make
-RUN yum remove -y golang
-RUN curl -O https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.8.3.linux-amd64.tar.gz && \
-    rm -f  go1.8.3.linux-amd64.tar.gz
-ENV PATH=${PATH}:/usr/local/go/bin
-ENV GOPATH=/go
-COPY . /go/src/github.com/openshift/image-inspector
-WORKDIR /go/src/github.com/openshift/image-inspector
-RUN make install-travis
-ENTRYPOINT make
-EOF
     docker build -t travis/image-inspector -f Dockerfile.travis .
 }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ go:
   - 1.7
 
 install:
-  - export PATH=$GOPATH/bin:./_tools/etcd/bin:$PATH
-  - make install-travis
+  - ./.travis.sh build
+
+services:
+  - docker
 
 script:
-  - make verify test-unit
+  - ./.travis.sh run
 
 notifications:
   irc: "chat.freenode.net#openshift-dev"

--- a/Dockerfile.travis
+++ b/Dockerfile.travis
@@ -1,0 +1,10 @@
+FROM travis/image-inspector-base
+RUN yum install -y \
+    git \
+    which \
+    make
+ENV GOPATH=/go
+COPY . /go/src/github.com/openshift/image-inspector
+WORKDIR /go/src/github.com/openshift/image-inspector
+RUN make install-travis
+ENTRYPOINT make

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -8,5 +8,7 @@ source "${CODE_ROOT}/hack/common.sh"
 echo "Detected go version: $(go version)"
 
 go get github.com/tools/godep
+go get github.com/onsi/ginkgo/ginkgo  # installs the ginkgo CLI
+go get github.com/onsi/gomega         # fetches the matcher library
 
 ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"

--- a/pkg/imageserver/imageserver_suite_test.go
+++ b/pkg/imageserver/imageserver_suite_test.go
@@ -1,0 +1,13 @@
+package imageserver_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestImageserver(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Imageserver Suite")
+}

--- a/pkg/imageserver/types.go
+++ b/pkg/imageserver/types.go
@@ -2,6 +2,7 @@ package imageserver
 
 import (
 	iiapi "github.com/openshift/image-inspector/pkg/api"
+	"net/http"
 )
 
 // ImageServer abstracts the serving of image information.
@@ -43,4 +44,7 @@ type ImageServerOptions struct {
 	// AuthToken is a Shared Secret used to validate HTTP Requests.
 	// AuthToken is set through ENV rather than passed as a parameter
 	AuthToken string
+	// Chroot indicates whether image-inspector will execute a chroot
+	// to the root directory of the image before serving its contents
+	Chroot bool
 }

--- a/pkg/imageserver/types.go
+++ b/pkg/imageserver/types.go
@@ -2,7 +2,6 @@ package imageserver
 
 import (
 	iiapi "github.com/openshift/image-inspector/pkg/api"
-	"net/http"
 )
 
 // ImageServer abstracts the serving of image information.

--- a/pkg/imageserver/webdav.go
+++ b/pkg/imageserver/webdav.go
@@ -13,31 +13,30 @@ import (
 )
 
 const (
-	// CHROOT_SERVE_PATH is the path to server if we are performing a chroot
+	// chrootServePath is the path to server if we are performing a chroot
 	// this probably does not belong here.
-	CHROOT_SERVE_PATH = "/"
-	// AUTH_TOKEN_HEADER is the custom HTTP Header used
+	chrootServePath = "/"
+	// authTokenHeader is the custom HTTP Header used
 	// to authenticate to image inspector.
-	// We use a custom auth header instead of Authorization
+	// Clients must use a custom auth header
+	// instead of standard Authorization
 	// because Kubernetes Proxy strips the default Auth Header
 	// from requests
-	AUTH_TOKEN_HEADER = "X-Auth-Token"
+	authTokenHeader = "X-Auth-Token"
 )
 
 // webdavImageServer implements ImageServer.
 type webdavImageServer struct {
-	opts   ImageServerOptions
-	chroot bool
+	opts ImageServerOptions
 }
 
 // ensures this always implements the interface or fail compilation.
 var _ ImageServer = &webdavImageServer{}
 
 // NewWebdavImageServer creates a new webdav image server.
-func NewWebdavImageServer(opts ImageServerOptions, chroot bool) ImageServer {
+func NewWebdavImageServer(opts ImageServerOptions) *webdavImageServer {
 	return &webdavImageServer{
-		opts:   opts,
-		chroot: chroot,
+		opts: opts,
 	}
 }
 
@@ -48,54 +47,58 @@ func (s *webdavImageServer) ServeImage(meta *iiapi.InspectorMetadata,
 	scanReport []byte,
 	htmlScanReport []byte,
 ) error {
+	handler, err := s.GetHandler(meta, ImageServeURL, results, scanReport, htmlScanReport)
+	if err != nil {
+		return fmt.Errorf("failed to initialize imageserver: %v", err)
+	}
+	log.Printf("Serving image content on webdav://%s%s", s.opts.ServePath, s.opts.ContentURL)
+	return http.ListenAndServe(s.opts.ServePath, handler)
+}
 
+// GetHandler Returns an http.Handler that serves the scan results
+// and the image using WebDAV
+func (s *webdavImageServer) GetHandler(meta *iiapi.InspectorMetadata,
+	ImageServeURL string,
+	results iiapi.ScanResult,
+	scanReport []byte,
+	htmlScanReport []byte,
+)(http.Handler, error) {
+	mux := http.NewServeMux()
 	servePath := ImageServeURL
-	if s.chroot {
+	if s.opts.Chroot {
 		if err := syscall.Chroot(ImageServeURL); err != nil {
-			return fmt.Errorf("Unable to chroot into %s: %v\n", ImageServeURL, err)
+			return nil, fmt.Errorf("Unable to chroot into %s: %v\n", ImageServeURL, err)
 		}
-		servePath = CHROOT_SERVE_PATH
+		servePath = chrootServePath
 	} else {
 		log.Printf("!!!WARNING!!! It is insecure to serve the image content without changing")
 		log.Printf("root (--chroot). Absolute-path symlinks in the image can lead to disclose")
 		log.Printf("information of the hosting system.")
 	}
 
-	log.Printf("Serving image content %s on webdav://%s%s", ImageServeURL, s.opts.ServePath, s.opts.ContentURL)
-
-	http.Handle(s.opts.HealthzURL, s.checkAuth(func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(s.opts.HealthzURL, func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("ok\n"))
-	}))
+	})
 
-	http.Handle(s.opts.APIURL, s.checkAuth(func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(s.opts.APIURL, func(w http.ResponseWriter, r *http.Request) {
 		body, err := json.MarshalIndent(s.opts.APIVersions, "", "  ")
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		w.Write(body)
-	}))
+	})
 
-	http.Handle(s.opts.MetadataURL, s.checkAuth(func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(s.opts.MetadataURL, func(w http.ResponseWriter, r *http.Request) {
 		body, err := json.MarshalIndent(meta, "", "  ")
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		w.Write(body)
-	}))
+	})
 
-	http.HandleFunc(s.opts.ResultAPIUrlPath, s.checkAuth(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("Content-Type", "application/json")
-		resultJSON, err := json.Marshal(results)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		w.Write(resultJSON)
-	}))
-
-	http.Handle(s.opts.ScanReportURL, s.checkAuth(func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(s.opts.ScanReportURL, func(w http.ResponseWriter, r *http.Request) {
 		if s.opts.ScanType != "" && meta.OpenSCAP.Status == iiapi.StatusSuccess {
 			w.Write(scanReport)
 		} else {
@@ -106,9 +109,9 @@ func (s *webdavImageServer) ServeImage(meta *iiapi.InspectorMetadata,
 				http.Error(w, "OpenSCAP option was not chosen", http.StatusNotFound)
 			}
 		}
-	}))
+	})
 
-	http.Handle(s.opts.HTMLScanReportURL, s.checkAuth(func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(s.opts.HTMLScanReportURL, func(w http.ResponseWriter, r *http.Request) {
 		if s.opts.ScanType != "" && meta.OpenSCAP.Status == iiapi.StatusSuccess && s.opts.HTMLScanReport {
 			w.Write(htmlScanReport)
 		} else {
@@ -119,34 +122,32 @@ func (s *webdavImageServer) ServeImage(meta *iiapi.InspectorMetadata,
 				http.Error(w, "OpenSCAP option was not chosen", http.StatusNotFound)
 			}
 		}
-	}))
+	})
 
-	http.Handle(s.opts.ContentURL, s.checkAuth((&webdav.Handler{
+	mux.Handle(s.opts.ContentURL, &webdav.Handler{
 		Prefix:     s.opts.ContentURL,
 		FileSystem: webdav.Dir(servePath),
 		LockSystem: webdav.NewMemLS(),
-	}).ServeHTTP))
+	})
 
-	return http.ListenAndServe(s.opts.ServePath, nil)
+	return s.checkAuth(mux), nil
 }
 
 //middleware handler for checking auth
-func (s *webdavImageServer) checkAuth(next func(http.ResponseWriter, *http.Request)) http.HandlerFunc {
+func (s *webdavImageServer) checkAuth(next http.Handler) http.Handler {
 	authToken := s.opts.AuthToken
 	// allow running without authorization
 	if len(authToken) == 0 {
 		log.Printf("!!!WARNING!!! It is insecure to serve the image content without setting")
 		log.Printf("an auth token. Please set INSPECTOR_AUTH_TOKEN in your environment.")
-		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			next(w, req)
-		})
+		return next
 	}
 
-	return func(w http.ResponseWriter, req *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if err := func() error {
-			token := req.Header.Get(AUTH_TOKEN_HEADER)
+			token := req.Header.Get(authTokenHeader)
 			if len(token) == 0 {
-				return fmt.Errorf("must provide %s header with this request", AUTH_TOKEN_HEADER)
+				return fmt.Errorf("must provide %s header with this request", authTokenHeader)
 			}
 			if token != authToken {
 				return fmt.Errorf("invalid auth token provided")
@@ -155,7 +156,7 @@ func (s *webdavImageServer) checkAuth(next func(http.ResponseWriter, *http.Reque
 		}(); err != nil {
 			http.Error(w, fmt.Sprintf("Authorization failed: %s", err.Error()), http.StatusUnauthorized)
 		} else {
-			next(w, req)
+			next.ServeHTTP(w, req)
 		}
-	}
+	})
 }

--- a/pkg/imageserver/webdav_test.go
+++ b/pkg/imageserver/webdav_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	docker "github.com/fsouza/go-dockerclient"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/image-inspector/pkg/api"
@@ -38,7 +39,12 @@ var _ = Describe("Webdav", func() {
 			Results:    []api.Result{},
 		}
 		dummyMetadata = &api.InspectorMetadata{
-			OpenSCAP: &api.OpenSCAPMetadata{},
+			Image: docker.Image{
+				ID: "dummy",
+			},
+			OpenSCAP: &api.OpenSCAPMetadata{
+				Status: api.StatusSuccess,
+			},
 		}
 		dummyScanReport     = []byte("this is a dummy scan report")
 		dummyHTMLScanReport = []byte("this is a dummy HTML scan report")
@@ -126,7 +132,8 @@ var _ = Describe("Webdav", func() {
 				var metadata api.InspectorMetadata
 				err = json.Unmarshal(body, &metadata)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(metadata).To(Equal(*dummyMetadata))
+				Expect(metadata.ID).To(Equal(dummyMetadata.ID))
+				Expect(metadata.OpenSCAP.Status).To(Equal(dummyMetadata.OpenSCAP.Status))
 			})
 		})
 

--- a/pkg/imageserver/webdav_test.go
+++ b/pkg/imageserver/webdav_test.go
@@ -1,0 +1,229 @@
+package imageserver_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/image-inspector/pkg/api"
+	"github.com/openshift/image-inspector/pkg/imageserver"
+)
+
+const (
+	versionTag             = "v1"
+	healthzPath            = "/healthz"
+	apiPrefix              = "/api"
+	contentPath            = apiPrefix + "/" + versionTag + "/content/"
+	metadataPath           = apiPrefix + "/" + versionTag + "/metadata"
+	openscapReportPath     = apiPrefix + "/" + versionTag + "/openscap"
+	openScapHTMLReportPath = apiPrefix + "/" + versionTag + "/openscap-report"
+	scanType               = "openscap"
+	authTokenHeader        = "X-Auth-Token"
+	authToken              = "12345"
+)
+
+var _ = Describe("Webdav", func() {
+	var (
+		server           *httptest.Server
+		options          imageserver.ImageServerOptions
+		dstPath          string
+		dummyScanResults = api.ScanResult{
+			APIVersion: api.DefaultResultsAPIVersion,
+			Results:    []api.Result{},
+		}
+		dummyMetadata = &api.InspectorMetadata{
+			OpenSCAP: &api.OpenSCAPMetadata{},
+		}
+		dummyScanReport     = []byte("this is a dummy scan report")
+		dummyHTMLScanReport = []byte("this is a dummy HTML scan report")
+		apiVersions         = api.APIVersions{Versions: []string{versionTag}}
+	)
+	JustBeforeEach(func() {
+		var err error
+		dstPath, err = ioutil.TempDir("", "")
+		Expect(err).NotTo(HaveOccurred())
+		options = imageserver.ImageServerOptions{
+			HealthzURL:        healthzPath,
+			APIURL:            apiPrefix,
+			APIVersions:       apiVersions,
+			MetadataURL:       metadataPath,
+			ContentURL:        contentPath,
+			ScanType:          scanType,
+			ScanReportURL:     openscapReportPath,
+			HTMLScanReport:    true,
+			HTMLScanReportURL: openScapHTMLReportPath,
+			AuthToken:         authToken,
+			Chroot:            false,
+		}
+		handler, err := imageserver.NewWebdavImageServer(options).GetHandler(dummyMetadata, dstPath, dummyScanResults, dummyScanReport, dummyHTMLScanReport)
+		Expect(err).NotTo(HaveOccurred())
+		server = httptest.NewServer(handler)
+	})
+	AfterEach(func() {
+		server.Close()
+		os.RemoveAll(dstPath)
+	})
+	Describe("Endpoints:", func() {
+		var u *url.URL
+		var expBody []byte
+		var status int
+		var body []byte
+		var err error
+		JustBeforeEach(func() {
+			var err error
+			u, err = url.Parse(server.URL)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		Describe("Healthz", func() {
+			JustBeforeEach(func() {
+				u.Path = healthzPath
+				expBody = []byte("ok\n")
+			})
+			Context("valid auth token", func() {
+				It("returns 200 and the text \"ok\\n\"", func() {
+					status, body, err = getWithAuth(u, authToken)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(status).To(Equal(http.StatusOK))
+					Expect(body).To(Equal(expBody))
+				})
+			})
+			Context("invalid auth token", func() {
+				It("returns 401", func() {
+					status, body, err = getWithAuth(u, "asdf")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(status).To(Equal(http.StatusUnauthorized))
+				})
+			})
+		})
+		Describe(apiPrefix, func() {
+			JustBeforeEach(func() {
+				u.Path = apiPrefix
+			})
+			It("returns a list of available api versions", func() {
+				status, body, err = getWithAuth(u, authToken)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(status).To(Equal(http.StatusOK))
+				var returnedVersions api.APIVersions
+				err = json.Unmarshal(body, &returnedVersions)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(returnedVersions).To(Equal(apiVersions))
+			})
+		})
+		Describe(metadataPath, func() {
+			JustBeforeEach(func() {
+				u.Path = metadataPath
+			})
+			It("returns the metadata the server was initialized with", func() {
+				status, body, err = getWithAuth(u, authToken)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(status).To(Equal(http.StatusOK))
+				var metadata api.InspectorMetadata
+				err = json.Unmarshal(body, &metadata)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(metadata).To(Equal(*dummyMetadata))
+			})
+		})
+
+		Describe(openscapReportPath, func() {
+			JustBeforeEach(func() {
+				u.Path = openscapReportPath
+			})
+			Context("OpenSCAP scan succeeded", func() {
+				BeforeEach(func() {
+					dummyMetadata.OpenSCAP.Status = api.StatusSuccess
+				})
+				It("should return 200 with the scan report", func() {
+					status, body, err = getWithAuth(u, authToken)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(status).To(Equal(http.StatusOK))
+					Expect(body).To(Equal(dummyScanReport))
+				})
+			})
+			Context("OpenSCAP scan errored", func() {
+				BeforeEach(func() {
+					dummyMetadata.OpenSCAP.Status = api.StatusError
+					dummyMetadata.OpenSCAP.ErrorMessage = "dummy error message"
+				})
+				It("should return 500 with the scan error message", func() {
+					status, body, err = getWithAuth(u, authToken)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(status).To(Equal(http.StatusInternalServerError))
+					Expect(string(body)).To(ContainSubstring(dummyMetadata.OpenSCAP.ErrorMessage))
+				})
+			})
+		})
+
+		Describe(openScapHTMLReportPath, func() {
+			JustBeforeEach(func() {
+				u.Path = openScapHTMLReportPath
+			})
+			Context("OpenSCAP scan succeeded", func() {
+				BeforeEach(func() {
+					dummyMetadata.OpenSCAP.Status = api.StatusSuccess
+				})
+				It("should return 200 with the scan report", func() {
+					status, body, err = getWithAuth(u, authToken)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(status).To(Equal(http.StatusOK))
+					Expect(body).To(Equal(dummyHTMLScanReport))
+				})
+			})
+			Context("OpenSCAP scan errored", func() {
+				BeforeEach(func() {
+					dummyMetadata.OpenSCAP.Status = api.StatusError
+					dummyMetadata.OpenSCAP.ErrorMessage = "dummy error message"
+				})
+				It("should return 500 with the scan error message", func() {
+					status, body, err = getWithAuth(u, authToken)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(status).To(Equal(http.StatusInternalServerError))
+					Expect(string(body)).To(ContainSubstring(dummyMetadata.OpenSCAP.ErrorMessage))
+				})
+			})
+		})
+		Describe("an HTTP GET of an expected file from "+contentPath, func() {
+			var (
+				tmpFile      *os.File
+				fileContents = "have a nice day"
+			)
+			JustBeforeEach(func() {
+				tmpFile, err = ioutil.TempFile(dstPath, "")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = tmpFile.WriteString(fileContents)
+				Expect(err).NotTo(HaveOccurred())
+				defer tmpFile.Close()
+				u.Path = contentPath + filepath.Base(tmpFile.Name())
+			})
+			It("should return status 200 and the contents of the file", func() {
+				status, body, err = getWithAuth(u, authToken)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(status).To(Equal(http.StatusOK))
+				Expect(string(body)).To(Equal(fileContents))
+			})
+		})
+	})
+})
+
+func getWithAuth(u *url.URL, token string) (int, []byte, error) {
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set(authTokenHeader, token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, err
+	}
+	resp.Body.Close()
+	return resp.StatusCode, body, nil
+}

--- a/pkg/inspector/image-inspector.go
+++ b/pkg/inspector/image-inspector.go
@@ -322,7 +322,7 @@ func (i *defaultImageInspector) pullImage(client *docker.Client) error {
 	}
 
 	// Try all the possible auth's from the config file
-	var authErr error
+	var err error
 	for name, auth := range imagePullAuths.Configs {
 		parsedErrors := make(chan error, 100)
 		defer func() { close(parsedErrors) }()
@@ -338,7 +338,7 @@ func (i *defaultImageInspector) pullImage(client *docker.Client) error {
 			}
 			go decodeDockerResponse(parsedErrors, reader)
 
-			if err := client.PullImage(imagePullOption, auth); err != nil {
+			if err = client.PullImage(imagePullOption, auth); err != nil {
 				parsedErrors <- err
 			}
 		}()
@@ -349,7 +349,7 @@ func (i *defaultImageInspector) pullImage(client *docker.Client) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("Unable to pull docker image: %v\n", authErr)
+	return fmt.Errorf("Unable to pull docker image: %v\n", err)
 }
 
 // createAndExtractImage creates a docker container based on the option's image with containerName.

--- a/pkg/inspector/image-inspector.go
+++ b/pkg/inspector/image-inspector.go
@@ -97,8 +97,9 @@ func NewDefaultImageInspector(opts iicmd.ImageInspectorOptions) ImageInspector {
 			HTMLScanReport:    opts.OpenScapHTML,
 			HTMLScanReportURL: OPENSCAP_REPORT_URL_PATH,
 			AuthToken:         opts.AuthToken,
+			Chroot:            opts.Chroot,
 		}
-		inspector.imageServer = apiserver.NewWebdavImageServer(imageServerOpts, opts.Chroot)
+		inspector.imageServer = apiserver.NewWebdavImageServer(imageServerOpts)
 	}
 	return inspector
 }

--- a/pkg/inspector/image-inspector_integration_test.go
+++ b/pkg/inspector/image-inspector_integration_test.go
@@ -2,16 +2,17 @@ package inspector_test
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/fsouza/go-dockerclient"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	iicmd "github.com/openshift/image-inspector/pkg/cmd"
 	. "github.com/openshift/image-inspector/pkg/inspector"
-	"net/http"
-	"strings"
-	"time"
-	"io/ioutil"
-	"os"
 )
 
 var _ = Describe("ImageInspector", func() {
@@ -37,7 +38,7 @@ var _ = Describe("ImageInspector", func() {
 		opts.DstPath, err = ioutil.TempDir("", "")
 		Expect(err).NotTo(HaveOccurred())
 
-			ii = NewDefaultImageInspector(*opts)
+		ii = NewDefaultImageInspector(*opts)
 		//serving blocks, so it needs to be done in a goroutine
 		go func() {
 			if err := ii.Inspect(); err != nil {
@@ -48,8 +49,8 @@ var _ = Describe("ImageInspector", func() {
 		if err := waitForImage(opts.URI, opts.Image, time.Minute*5); err != nil {
 			panic(err)
 		}
-		//allow 30s to start serving http
-		if err := waitForServer(opts.Serve, time.Second*30); err != nil {
+		//allow 40s to start serving http
+		if err := waitForServer(opts.Serve, time.Second*40); err != nil {
 			panic(err)
 		}
 	})

--- a/pkg/inspector/image-inspector_integration_test.go
+++ b/pkg/inspector/image-inspector_integration_test.go
@@ -1,5 +1,3 @@
-// +build integrationtest
-
 package inspector_test
 
 import (
@@ -8,11 +6,12 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	iicmd "github.com/openshift/image-inspector/pkg/cmd"
-	"github.com/openshift/image-inspector/pkg/imageserver"
 	. "github.com/openshift/image-inspector/pkg/inspector"
 	"net/http"
 	"strings"
 	"time"
+	"io/ioutil"
+	"os"
 )
 
 var _ = Describe("ImageInspector", func() {
@@ -26,35 +25,38 @@ var _ = Describe("ImageInspector", func() {
 			Timeout: time.Minute,
 		}
 	)
-	JustBeforeEach(func() {
+	//note: no expects in this block
+	//we just begin the http server here
+	BeforeSuite(func() {
+		var err error
 		opts = iicmd.NewDefaultImageInspectorOptions()
 		opts.Serve = serve
 		opts.AuthToken = validToken
-		opts.Image = "fedora:22"
+		opts.Image = "registry.access.redhat.com/rhel7:latest"
 		opts.ScanType = "openscap"
+		opts.DstPath, err = ioutil.TempDir("", "")
+		Expect(err).NotTo(HaveOccurred())
 
-		ii = NewDefaultImageInspector(*opts)
-
+			ii = NewDefaultImageInspector(*opts)
+		//serving blocks, so it needs to be done in a goroutine
+		go func() {
+			if err := ii.Inspect(); err != nil {
+				panic(err)
+			}
+		}()
+		//allow 5 minutes to pull image
+		if err := waitForImage(opts.URI, opts.Image, time.Minute*5); err != nil {
+			panic(err)
+		}
+		//allow 30s to start serving http
+		if err := waitForServer(opts.Serve, time.Second*30); err != nil {
+			panic(err)
+		}
+	})
+	AfterSuite(func() {
+		os.RemoveAll(opts.DstPath)
 	})
 	Describe(".Inspect()", func() {
-		//note: no expects in this block
-		//we just begin the http server here
-		It("starts running witouth error", func() {
-			//serving blocks, so it needs to be done in a goroutine
-			go func() {
-				if err := ii.Inspect(); err != nil {
-					panic(err)
-				}
-			}()
-			//allow 3 minutes to pull image
-			if err := waitForImage(opts.URI, opts.Image, time.Minute*3); err != nil {
-				panic(err)
-			}
-			//allow 30s to start serving http
-			if err := waitForServer(opts.Serve, time.Second*30); err != nil {
-				panic(err)
-			}
-		})
 
 		paths := []string{
 			//HEALTHZ_URL_PATH,
@@ -76,7 +78,7 @@ var _ = Describe("ImageInspector", func() {
 				})
 				Context("with incorrect authentication token", func() {
 					BeforeEach(func() {
-						req.Header.Set(imageserver.AUTH_TOKEN_HEADER, invalidToken)
+						req.Header.Set("X-Auth-Token", invalidToken)
 					})
 					It("should fail with status http.Status BadRequest", func() {
 						res, err := client.Do(req)
@@ -86,7 +88,7 @@ var _ = Describe("ImageInspector", func() {
 				})
 				Context("with correct authentication token", func() {
 					BeforeEach(func() {
-						req.Header.Set(imageserver.AUTH_TOKEN_HEADER, validToken)
+						req.Header.Set("X-Auth-Token", validToken)
 					})
 					It("should authorize the request", func() {
 						res, err := client.Do(req)

--- a/pkg/inspector/inspector_suite_test.go
+++ b/pkg/inspector/inspector_suite_test.go
@@ -1,5 +1,3 @@
-// +build integrationtest
-
 package inspector_test
 
 import (

--- a/test/end-to-end/e2e.sh
+++ b/test/end-to-end/e2e.sh
@@ -16,16 +16,17 @@ ii::util::environment::setup_time_vars
 
 # test args
 ii::cmd::expect_failure_and_text "image-inspector --help" "Usage of"
-ii::cmd::expect_failure_and_text "image-inspector" "Docker image to inspect must be specified"
+ii::cmd::expect_failure_and_text "image-inspector" "Error: docker image to inspect must be specified"
 ii::cmd::expect_failure_and_text "image-inspector --image=fedora:22 --dockercfg=badfile" "badfile does not exist"
-ii::cmd::expect_failure_and_text "image-inspector --image=fedora:22 --dockercfg=badfile --username=foo" "Only specify dockercfg file or username/password pair for authentication"
+ii::cmd::expect_failure_and_text "image-inspector --image=fedora:22 --dockercfg=badfile --username=foo" "Error: only specify dockercfg file or username/password pair for authentication"
 ii::cmd::expect_failure_and_text "image-inspector --image=fedora:22 --password-file=foo" "foo does not exist"
 ii::cmd::expect_failure_and_text "image-inspector --image=fedora:22 --scan-type=foo" "foo is not one of the available scan-type"
 ii::cmd::expect_failure_and_text "image-inspector --image=fedora:22 --pull-policy=foo" "foo is not one of the available pull-policy"
+ii::cmd::expect_failure_and_text "image-inspector --image=fedora:22 --scan-type=foo" "Error: foo is not one of the available scan-types which are \[openscap clamav\]"
 
 
 # test extraction
-ii::cmd::expect_success_and_text "image-inspector --image=fedora:22 2>&1" "Extracting image fedora:22"
+ii::cmd::expect_success_and_text "image-inspector --image=fedora:22 --scan-type=openscap 2>&1" "Extracting image fedora:22"
 
 # TODO
 # test serving


### PR DESCRIPTION
This PR adds Integration tests will attempt to pull and scan an image without throwing an error. In order to accomplish this with our CI (travis), travis now runs tests inside a docker container (as travis does not support centos-based builds).

The PR also adds a set of integration tests for the WebDAV server (ensures http endpoints behave as expected).

the success of `docker build` will now also be tested by travis.
 
Additional changes:
- changes to some constant names
- `ImageServer` interface now implements `GetHandler` which returns an `http.Handler` rather than `ServeImage`, allowing the image server to be tested, as well as for middleware to be more easily added to the http Handler chain.

The additional tests are implemented with the [Ginkgo Test Framework](https://github.com/onsi/ginkgo). Ginkgo tests are compatible with `go test`