### PR TITLE
return useful error on clamd initialization

### DIFF
--- a/pkg/clamav/clamav_test.go
+++ b/pkg/clamav/clamav_test.go
@@ -60,9 +60,7 @@ func TestScan(t *testing.T) {
 }
 
 func TestNewScanner(t *testing.T) {
-	scanner := NewScanner("missing.socket")
-	_, _, err := scanner.Scan(".", nil)
-	if err == nil {
+	if _, err := NewScanner("missing.socket"); err == nil {
 		t.Errorf("expected socket error, got none")
 	}
 }

--- a/pkg/clamav/scanner.go
+++ b/pkg/clamav/scanner.go
@@ -23,20 +23,20 @@ type ClamScanner struct {
 
 var _ api.Scanner = &ClamScanner{}
 
-func NewScanner(socket string) api.Scanner {
-	scanner := ClamScanner{
-		Socket: socket,
-	}
+func NewScanner(socket string) (api.Scanner, error) {
 	// TODO: Make the ignoreNegatives configurable
-	scanner.clamd, _ = clamav.NewClamdSession(scanner.Socket, true)
-	return &scanner
+	clamSession, err := clamav.NewClamdSession(socket, true)
+	if err != nil {
+		return nil, err
+	}
+	return &ClamScanner{
+		Socket: socket,
+		clamd: clamSession,
+	}, nil
 }
 
 // Scan will scan the image
 func (s *ClamScanner) Scan(path string, image *docker.Image) ([]api.Result, interface{}, error) {
-	if s.clamd == nil {
-		return nil, nil, fmt.Errorf("unable to start clamd session")
-	}
 	scanResults := []api.Result{}
 	// Useful for debugging
 	scanStarted := time.Now()

--- a/pkg/inspector/image-inspector.go
+++ b/pkg/inspector/image-inspector.go
@@ -165,7 +165,10 @@ func (i *defaultImageInspector) Inspect() error {
 		scanResults.Results = append(scanResults.Results, results...)
 
 	case "clamav":
-		scanner = clamav.NewScanner(i.opts.ClamSocket)
+		scanner, err = clamav.NewScanner(i.opts.ClamSocket)
+		if err != nil {
+			return fmt.Errorf("failed to initialize clamav scanner: %v", err)
+		}
 		results, _, err := scanner.Scan(i.opts.DstPath, &i.meta.Image)
 		if err != nil {
 			log.Printf("DEBUG: Unable to scan image %q with ClamAV: %v", i.opts.Image, err)


### PR DESCRIPTION
this PR adds a more useful error if initializing the ClamAV scanner fails. Currently if initializing fails, the user gets an error "unable to start clamd session" while information about the actual error (e.g. unable to connect to clamav socket) is lost. This change ensures the error will be bubbled up to the caller