### PR TITLE
Code constants cleanup and refactoring

### DIFF
--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -7,8 +7,9 @@ import (
 
 	iiapi "github.com/openshift/image-inspector/pkg/api"
 
-	util "github.com/openshift/image-inspector/pkg/util"
 	"os"
+
+	util "github.com/openshift/image-inspector/pkg/util"
 )
 
 const DefaultDockerSocketLocation = "unix:///var/run/docker.sock"

--- a/pkg/imageserver/types.go
+++ b/pkg/imageserver/types.go
@@ -43,4 +43,7 @@ type ImageServerOptions struct {
 	// AuthToken is a Shared Secret used to validate HTTP Requests.
 	// AuthToken is set through ENV rather than passed as a parameter
 	AuthToken string
+	// Chroot indicates whether image-inspector will execute a chroot
+	// to the root directory of the image before serving its contents
+	Chroot bool
 }

--- a/pkg/inspector/image-inspector_ginkgo_test.go
+++ b/pkg/inspector/image-inspector_ginkgo_test.go
@@ -4,15 +4,16 @@ package inspector_test
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/fsouza/go-dockerclient"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	iicmd "github.com/openshift/image-inspector/pkg/cmd"
 	"github.com/openshift/image-inspector/pkg/imageserver"
 	. "github.com/openshift/image-inspector/pkg/inspector"
-	"net/http"
-	"strings"
-	"time"
 )
 
 var _ = Describe("ImageInspector", func() {


### PR DESCRIPTION
- [x] change some public consts to private; use camel case
- [x] move chroot image serve option into `ImageServerOptions`
- [x] separate new http Handler logic from http.ListenAndServe
- [x] clean up routes / handlers in webdav server
- [x] goimports / gofmt