### PR TITLE
Add integration tests to Travis CI jobs

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+function build_container(){
+    docker build -t travis/image-inspector-base .
+    docker build -t travis/image-inspector -f Dockerfile.travis .
+}
+
+function run_tests(){
+  docker run --rm --privileged \
+             -v /var/run/docker.sock:/var/run/docker.sock \
+             --entrypoint make \
+             travis/image-inspector verify test-unit
+}
+
+function usage() {
+    echo "usage: .travis.sh build|run"
+    exit 1
+}
+
+case "$1" in
+    build)
+        build_container
+        ;;
+    run)
+        run_tests
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ go:
   - 1.7
 
 install:
-  - export PATH=$GOPATH/bin:./_tools/etcd/bin:$PATH
-  - make install-travis
+  - ./.travis.sh build
+
+services:
+  - docker
 
 script:
-  - make verify test-unit
+  - ./.travis.sh run
 
 notifications:
   irc: "chat.freenode.net#openshift-dev"

--- a/Dockerfile.travis
+++ b/Dockerfile.travis
@@ -1,0 +1,10 @@
+FROM travis/image-inspector-base
+RUN yum install -y \
+    git \
+    which \
+    make
+ENV GOPATH=/go
+COPY . /go/src/github.com/openshift/image-inspector
+WORKDIR /go/src/github.com/openshift/image-inspector
+RUN make install-travis
+ENTRYPOINT make

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -8,5 +8,7 @@ source "${CODE_ROOT}/hack/common.sh"
 echo "Detected go version: $(go version)"
 
 go get github.com/tools/godep
+go get github.com/onsi/ginkgo/ginkgo  # installs the ginkgo CLI
+go get github.com/onsi/gomega         # fetches the matcher library
 
 ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"

--- a/pkg/imageserver/imageserver_suite_test.go
+++ b/pkg/imageserver/imageserver_suite_test.go
@@ -1,4 +1,4 @@
-package inspector_test
+package imageserver
 
 import (
 	. "github.com/onsi/ginkgo"
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestInspector(t *testing.T) {
+func TestImageserver(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Inspector Suite")
+	RunSpecs(t, "Imageserver Suite")
 }

--- a/pkg/imageserver/webdav_test.go
+++ b/pkg/imageserver/webdav_test.go
@@ -1,0 +1,226 @@
+package imageserver
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	docker "github.com/fsouza/go-dockerclient"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/image-inspector/pkg/api"
+)
+
+const (
+	versionTag             = "v1"
+	healthzPath            = "/healthz"
+	apiPrefix              = "/api"
+	contentPath            = apiPrefix + "/" + versionTag + "/content/"
+	metadataPath           = apiPrefix + "/" + versionTag + "/metadata"
+	openscapReportPath     = apiPrefix + "/" + versionTag + "/openscap"
+	openScapHTMLReportPath = apiPrefix + "/" + versionTag + "/openscap-report"
+	scanType               = "openscap"
+	authToken              = "12345"
+)
+
+var _ = Describe("Webdav", func() {
+	var (
+		server           *httptest.Server
+		options          ImageServerOptions
+		dstPath          string
+		dummyScanResults = api.ScanResult{
+			APIVersion: api.DefaultResultsAPIVersion,
+			Results:    []api.Result{},
+		}
+		dummyMetadata = &api.InspectorMetadata{
+			Image: docker.Image{
+				ID: "dummy",
+			},
+			OpenSCAP: &api.OpenSCAPMetadata{
+				Status: api.StatusSuccess,
+			},
+		}
+		dummyScanReport     = []byte("this is a dummy scan report")
+		dummyHTMLScanReport = []byte("this is a dummy HTML scan report")
+		apiVersions         = api.APIVersions{Versions: []string{versionTag}}
+	)
+	JustBeforeEach(func() {
+		var err error
+		dstPath, err = ioutil.TempDir("", "")
+		Expect(err).NotTo(HaveOccurred())
+		options = ImageServerOptions{
+			HealthzURL:        healthzPath,
+			APIURL:            apiPrefix,
+			APIVersions:       apiVersions,
+			MetadataURL:       metadataPath,
+			ContentURL:        contentPath,
+			ScanType:          scanType,
+			ScanReportURL:     openscapReportPath,
+			HTMLScanReport:    true,
+			HTMLScanReportURL: openScapHTMLReportPath,
+			AuthToken:         authToken,
+			Chroot:            false,
+		}
+		handler, err := NewWebdavImageServer(options).(*webdavImageServer).GetHandler(dummyMetadata, dstPath, dummyScanResults, dummyScanReport, dummyHTMLScanReport)
+		Expect(err).NotTo(HaveOccurred())
+		server = httptest.NewServer(handler)
+	})
+	AfterEach(func() {
+		server.Close()
+		os.RemoveAll(dstPath)
+	})
+	Describe("Endpoints:", func() {
+		var u *url.URL
+		JustBeforeEach(func() {
+			var err error
+			u, err = url.Parse(server.URL)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		Describe("Healthz", func() {
+			JustBeforeEach(func() {
+				u.Path = healthzPath
+			})
+			Context("valid auth token", func() {
+				It("returns 200 and the text \"ok\\n\"", func() {
+					status, body, err := getWithAuth(u, authToken)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(status).To(Equal(http.StatusOK))
+					Expect(body).To(Equal([]byte("ok\n")))
+				})
+			})
+			Context("invalid auth token", func() {
+				It("returns 401", func() {
+					status, _, err := getWithAuth(u, "asdf")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(status).To(Equal(http.StatusUnauthorized))
+				})
+			})
+		})
+		Describe(apiPrefix, func() {
+			JustBeforeEach(func() {
+				u.Path = apiPrefix
+			})
+			It("returns a list of available api versions", func() {
+				status, body, err := getWithAuth(u, authToken)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(status).To(Equal(http.StatusOK))
+				var returnedVersions api.APIVersions
+				err = json.Unmarshal(body, &returnedVersions)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(returnedVersions).To(Equal(apiVersions))
+			})
+		})
+		Describe(metadataPath, func() {
+			JustBeforeEach(func() {
+				u.Path = metadataPath
+			})
+			It("returns the metadata the server was initialized with", func() {
+				status, body, err := getWithAuth(u, authToken)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(status).To(Equal(http.StatusOK))
+				var metadata api.InspectorMetadata
+				err = json.Unmarshal(body, &metadata)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(metadata.ID).To(Equal(dummyMetadata.ID))
+				Expect(metadata.OpenSCAP.Status).To(Equal(dummyMetadata.OpenSCAP.Status))
+			})
+		})
+
+		Describe(openscapReportPath, func() {
+			JustBeforeEach(func() {
+				u.Path = openscapReportPath
+			})
+			Context("OpenSCAP scan succeeded", func() {
+				BeforeEach(func() {
+					dummyMetadata.OpenSCAP.Status = api.StatusSuccess
+				})
+				It("should return 200 with the scan report", func() {
+					status, body, err := getWithAuth(u, authToken)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(status).To(Equal(http.StatusOK))
+					Expect(body).To(Equal(dummyScanReport))
+				})
+			})
+			Context("OpenSCAP scan errored", func() {
+				BeforeEach(func() {
+					dummyMetadata.OpenSCAP.Status = api.StatusError
+					dummyMetadata.OpenSCAP.ErrorMessage = "dummy error message"
+				})
+				It("should return 500 with the scan error message", func() {
+					status, body, err := getWithAuth(u, authToken)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(status).To(Equal(http.StatusInternalServerError))
+					Expect(string(body)).To(ContainSubstring(dummyMetadata.OpenSCAP.ErrorMessage))
+				})
+			})
+		})
+
+		Describe(openScapHTMLReportPath, func() {
+			JustBeforeEach(func() {
+				u.Path = openScapHTMLReportPath
+			})
+			Context("OpenSCAP scan succeeded", func() {
+				BeforeEach(func() {
+					dummyMetadata.OpenSCAP.Status = api.StatusSuccess
+				})
+				It("should return 200 with the scan report", func() {
+					status, body, err := getWithAuth(u, authToken)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(status).To(Equal(http.StatusOK))
+					Expect(body).To(Equal(dummyHTMLScanReport))
+				})
+			})
+			Context("OpenSCAP scan errored", func() {
+				BeforeEach(func() {
+					dummyMetadata.OpenSCAP.Status = api.StatusError
+					dummyMetadata.OpenSCAP.ErrorMessage = "dummy error message"
+				})
+				It("should return 500 with the scan error message", func() {
+					status, body, err := getWithAuth(u, authToken)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(status).To(Equal(http.StatusInternalServerError))
+					Expect(string(body)).To(ContainSubstring(dummyMetadata.OpenSCAP.ErrorMessage))
+				})
+			})
+		})
+		Describe("an HTTP GET of an expected file from "+contentPath, func() {
+			fileContents := "have a nice day"
+			JustBeforeEach(func() {
+				tmpFile, err := ioutil.TempFile(dstPath, "")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = tmpFile.WriteString(fileContents)
+				Expect(err).NotTo(HaveOccurred())
+				defer tmpFile.Close()
+				u.Path = contentPath + filepath.Base(tmpFile.Name())
+			})
+			It("should return status 200 and the contents of the file", func() {
+				status, body, err := getWithAuth(u, authToken)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(status).To(Equal(http.StatusOK))
+				Expect(string(body)).To(Equal(fileContents))
+			})
+		})
+	})
+})
+
+func getWithAuth(u *url.URL, token string) (int, []byte, error) {
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set(authTokenHeader, token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, err
+	}
+	resp.Body.Close()
+	return resp.StatusCode, body, nil
+}

--- a/test/end-to-end/e2e.sh
+++ b/test/end-to-end/e2e.sh
@@ -16,16 +16,17 @@ ii::util::environment::setup_time_vars
 
 # test args
 ii::cmd::expect_failure_and_text "image-inspector --help" "Usage of"
-ii::cmd::expect_failure_and_text "image-inspector" "Docker image to inspect must be specified"
+ii::cmd::expect_failure_and_text "image-inspector" "Error: docker image to inspect must be specified"
 ii::cmd::expect_failure_and_text "image-inspector --image=fedora:22 --dockercfg=badfile" "badfile does not exist"
-ii::cmd::expect_failure_and_text "image-inspector --image=fedora:22 --dockercfg=badfile --username=foo" "Only specify dockercfg file or username/password pair for authentication"
+ii::cmd::expect_failure_and_text "image-inspector --image=fedora:22 --dockercfg=badfile --username=foo" "Error: only specify dockercfg file or username/password pair for authentication"
 ii::cmd::expect_failure_and_text "image-inspector --image=fedora:22 --password-file=foo" "foo does not exist"
 ii::cmd::expect_failure_and_text "image-inspector --image=fedora:22 --scan-type=foo" "foo is not one of the available scan-type"
 ii::cmd::expect_failure_and_text "image-inspector --image=fedora:22 --pull-policy=foo" "foo is not one of the available pull-policy"
+ii::cmd::expect_failure_and_text "image-inspector --image=fedora:22 --scan-type=foo" "Error: foo is not one of the available scan-types which are \[openscap clamav\]"
 
 
 # test extraction
-ii::cmd::expect_success_and_text "image-inspector --image=fedora:22 2>&1" "Extracting image fedora:22"
+ii::cmd::expect_success_and_text "image-inspector --image=fedora:22 --scan-type=openscap 2>&1" "Extracting image fedora:22"
 
 # TODO
 # test serving


### PR DESCRIPTION
This PR adds Integration tests will attempt to pull and scan an image without throwing an error. In order to accomplish this with our CI (travis), travis now runs tests inside a docker container (as travis does not support centos-based builds).

The PR also adds a set of integration tests for the WebDAV server (ensures http endpoints behave as expected).

the success of `docker build` will now also be tested by travis.
 
The additional tests are implemented with the [Ginkgo Test Framework](https://github.com/onsi/ginkgo). Ginkgo tests are compatible with `go test`
