### PR TITLE
Add option to scan for an existing container

### DIFF
--- a/cmd/image-inspector.go
+++ b/cmd/image-inspector.go
@@ -16,7 +16,9 @@ func main() {
 	inspectorOptions := iicmd.NewDefaultImageInspectorOptions()
 
 	flag.StringVar(&inspectorOptions.URI, "docker", inspectorOptions.URI, "Daemon socket to connect to")
-	flag.StringVar(&inspectorOptions.Image, "image", inspectorOptions.Image, "Docker image to inspect")
+	flag.StringVar(&inspectorOptions.Image, "image", inspectorOptions.Image, "Docker image to inspect (cannot be used with the container option)")
+	flag.StringVar(&inspectorOptions.Container, "container", inspectorOptions.Container, "Docker container to inspect (cannot be used with the image option)")
+	flag.BoolVar(&inspectorOptions.ScanContainerChanges, "container-changes", inspectorOptions.ScanContainerChanges, "Scan only changed files inside running container")
 	flag.StringVar(&inspectorOptions.DstPath, "path", inspectorOptions.DstPath, "Destination path for the image files")
 	flag.StringVar(&inspectorOptions.Serve, "serve", inspectorOptions.Serve, "Host and port where to serve the image with webdav")
 	flag.BoolVar(&inspectorOptions.Chroot, "chroot", inspectorOptions.Chroot, "Change root when serving the image with webdav")

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"os"
 	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
@@ -33,8 +34,9 @@ type ScanResult struct {
 	ImageName string `json:"imageName"`
 	// ImageIUD is a SHA256 identifier of the scanned image
 	// Note that we don't set the imageID when container is the target of the scan.
-	// FIXME: We should add ContainerID here in that case.
 	ImageID string `json:"imageID,omitempty"`
+	// ContainerID contains the docker container to inspect.
+	ContainerID string `json:"containerID,omitempty"`
 	// Results contains compacted results of various scans performed on the image.
 	// Empty results means no problems were found with the given image.
 	Results []Result `json:"results,omitempty"`
@@ -103,12 +105,15 @@ type APIVersions struct {
 	Versions []string `json:"versions"`
 }
 
+// FilesFilter desribes callback to filter files.
+type FilesFilter func(string, os.FileInfo) bool
+
 // Scanner interface that all scanners should define.
 type Scanner interface {
 	// Scan will perform a scan on the given path for the given Image.
 	// It should return compacted results for JSON serialization and additionally scanner
 	// specific results with more details. The context object can be used to cancel the scanning process.
-	Scan(ctx context.Context, path string, image *docker.Image) ([]Result, interface{}, error)
+	Scan(ctx context.Context, path string, image *docker.Image, filter FilesFilter) ([]Result, interface{}, error)
 
 	// Name is the scanner's name
 	Name() string

--- a/pkg/clamav/clamav_test.go
+++ b/pkg/clamav/clamav_test.go
@@ -42,7 +42,7 @@ func TestScan(t *testing.T) {
 	ctx := context.Background()
 	scanner := &ClamScanner{clamd: &fakeClamSession{t: t}}
 
-	results, _, err := scanner.Scan(ctx, "/foo/bar", nil)
+	results, _, err := scanner.Scan(ctx, "/foo/bar", nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/pkg/clamav/scanner.go
+++ b/pkg/clamav/scanner.go
@@ -37,14 +37,14 @@ func NewScanner(socket string) (api.Scanner, error) {
 }
 
 // Scan will scan the image
-func (s *ClamScanner) Scan(ctx context.Context, path string, image *docker.Image) ([]api.Result, interface{}, error) {
+func (s *ClamScanner) Scan(ctx context.Context, path string, image *docker.Image, filter api.FilesFilter) ([]api.Result, interface{}, error) {
 	scanResults := []api.Result{}
 	// Useful for debugging
 	scanStarted := time.Now()
 	defer func() {
 		log.Printf("clamav scan took %ds (%d problems found)", int64(time.Since(scanStarted).Seconds()), len(scanResults))
 	}()
-	if err := s.clamd.ScanPath(ctx, path, nil); err != nil {
+	if err := s.clamd.ScanPath(ctx, path, clamav.FilterFiles(filter)); err != nil {
 		return nil, nil, err
 	}
 	s.clamd.WaitTillDone()

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -35,6 +35,10 @@ type ImageInspectorOptions struct {
 	URI string
 	// Image contains the docker image to inspect.
 	Image string
+	// Container contains the docker container to inspect.
+	Container string
+	// ScanContainerChanges controls whether or not whole rootfs will be scanned.
+	ScanContainerChanges bool
 	// DstPath is the destination path for image files.
 	DstPath string
 	// Serve holds the host and port for where to serve the image with webdav.
@@ -91,8 +95,14 @@ func (i *ImageInspectorOptions) Validate() error {
 	if len(i.URI) == 0 {
 		return fmt.Errorf("docker socket connection must be specified")
 	}
-	if len(i.Image) == 0 {
-		return fmt.Errorf("docker image to inspect must be specified")
+	if len(i.Image) > 0 && len(i.Container) > 0 {
+		return fmt.Errorf("options container and image are mutually exclusive")
+	}
+	if len(i.Image) == 0 && len(i.Container) == 0 {
+		return fmt.Errorf("docker image or container must be specified to inspect")
+	}
+	if i.ScanContainerChanges && len(i.Container) == 0 {
+		return fmt.Errorf("please specify docker container")
 	}
 	if len(i.DockerCfg.Values) > 0 && len(i.Username) > 0 {
 		return fmt.Errorf("only specify dockercfg file or username/password pair for authentication")

--- a/pkg/cmd/types_test.go
+++ b/pkg/cmd/types_test.go
@@ -71,6 +71,10 @@ func TestValidate(t *testing.T) {
 	noSuchPullPolicy.Image = "image"
 	noSuchPullPolicy.PullPolicy = "whatisdocker?"
 
+	conflictOptions := NewDefaultImageInspectorOptions()
+	conflictOptions.Image = "image"
+	conflictOptions.Container = "container"
+
 	tests := map[string]struct {
 		inspector      *ImageInspectorOptions
 		shouldValidate bool
@@ -90,6 +94,7 @@ func TestValidate(t *testing.T) {
 		"bad config with html and no scan":    {inspector: badScanOptionsHTMLnoScan, shouldValidate: false},
 		"bad config with html and wrong scan": {inspector: badScanOptionsHTMLWrongScan, shouldValidate: false},
 		"no such pull policy available":       {inspector: noSuchPullPolicy, shouldValidate: false},
+		"conflict options":                    {inspector: conflictOptions, shouldValidate: false},
 	}
 
 	for k, v := range tests {

--- a/pkg/inspector/image-inspector_test.go
+++ b/pkg/inspector/image-inspector_test.go
@@ -24,13 +24,13 @@ type SuccWithReportMockScanner struct {
 	SuccMockScanner
 }
 
-func (ms *FailMockScanner) Scan(context.Context, string, *docker.Image) ([]iiapi.Result, interface{}, error) {
+func (ms *FailMockScanner) Scan(context.Context, string, *docker.Image, iiapi.FilesFilter) ([]iiapi.Result, interface{}, error) {
 	return nil, nil, fmt.Errorf("FAIL SCANNER!")
 }
 func (ms *FailMockScanner) Name() string {
 	return "MockScanner"
 }
-func (ms *SuccMockScanner) Scan(context.Context, string, *docker.Image) ([]iiapi.Result, interface{}, error) {
+func (ms *SuccMockScanner) Scan(context.Context, string, *docker.Image, iiapi.FilesFilter) ([]iiapi.Result, interface{}, error) {
 	return []iiapi.Result{}, nil, nil
 }
 
@@ -45,7 +45,7 @@ func TestScanImage(t *testing.T) {
 		"Happy Flow":            {ii: defaultImageInspector{}, s: &SuccMockScanner{}, shouldFail: false},
 	} {
 		v.ii.opts.DstPath = "here"
-		_, _, err := v.s.Scan(ctx, v.ii.opts.DstPath, nil)
+		_, _, err := v.s.Scan(ctx, v.ii.opts.DstPath, nil, nil)
 		if v.shouldFail && err == nil {
 			t.Errorf("%s should have failed but it didn't!", k)
 		}

--- a/pkg/openscap/openscap.go
+++ b/pkg/openscap/openscap.go
@@ -191,7 +191,7 @@ func (s *defaultOSCAPScanner) oscapChroot(ctx context.Context, oscapArgs ...stri
 	return out, err
 }
 
-func (s *defaultOSCAPScanner) Scan(ctx context.Context, mountPath string, image *docker.Image) ([]iiapi.Result, interface{}, error) {
+func (s *defaultOSCAPScanner) Scan(ctx context.Context, mountPath string, image *docker.Image, filter iiapi.FilesFilter) ([]iiapi.Result, interface{}, error) {
 	fi, err := os.Stat(mountPath)
 	if err != nil || os.IsNotExist(err) || !fi.IsDir() {
 		return nil, nil, fmt.Errorf("%s is not a directory, error: %v", mountPath, err)

--- a/pkg/openscap/openscap_test.go
+++ b/pkg/openscap/openscap_test.go
@@ -160,7 +160,7 @@ func TestScan(t *testing.T) {
 	}
 
 	for k, v := range tests {
-		_, report, err := v.ts.Scan(ctx, ".", &docker.Image{})
+		_, report, err := v.ts.Scan(ctx, ".", &docker.Image{}, nil)
 		if v.shouldFail && !strings.Contains(err.Error(), v.expectedError.Error()) {
 			t.Errorf("%s expected to cause error:\n%v\nBut got:\n%v", k, v.expectedError, err)
 		}
@@ -182,7 +182,7 @@ func TestScan(t *testing.T) {
 		"mount path is not a directory": {"openscap.go", &docker.Image{}},
 		"image is nil":                  {".", nil},
 	} {
-		if _, _, err := tsSuccessMocks.Scan(ctx, v.mountPath, v.image); err == nil {
+		if _, _, err := tsSuccessMocks.Scan(ctx, v.mountPath, v.image, nil); err == nil {
 			t.Errorf("%s did not fail", k)
 		}
 	}

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,6 +1,6 @@
 golang.org/x/net 570fa1c91359c1869590e9cedf3b53162a51a167
 github.com/fsouza/go-dockerclient bf97c77db7c945cbcdbf09d56c6f87a66f54537b
-github.com/openshift/clam-scanner 5f5e14d051dc36567d6e31f2649ed1d65a9d43a3
+github.com/openshift/clam-scanner 10301190ffc03e918609f280458bd6bb26e779e2
 github.com/subchen/go-xmldom 93fb82989feca2cc04221f1483c8fe1dc98ed503
 github.com/antchfx/xpath 0851b60062c5ccde520ce15765695b8525d4a034
 github.com/golang/glog 23def4e6c14b4da8ac2ed8007337bc5eb5007998

--- a/vendor/github.com/openshift/clam-scanner/pkg/clamav/session.go
+++ b/vendor/github.com/openshift/clam-scanner/pkg/clamav/session.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-type FilterFiles map[string]struct{}
+type FilterFiles func(string, os.FileInfo) bool
 
 // ClamdSession is the interface for a Clamav session.
 type ClamdSession interface {
@@ -307,12 +307,12 @@ func (s *clamdSession) ScanPath(ctx context.Context, rootPath string, filter Fil
 		}
 
 		if filter != nil {
-			if _, ok := filter[path]; !ok {
-				return nil
+			if !filter(path, fileInfo) {
+				return filepath.SkipDir
 			}
 		}
 
-		if !fileInfo.Mode().IsRegular() {
+		if path == rootPath || !fileInfo.Mode().IsRegular() {
 			return nil
 		}
 


### PR DESCRIPTION
As follow up of #55 I added the ability to scan existing containers. All options are applicable to the image (such as `-scan-type`, `-post-results-url` etc.) can be applied to the scanning of the container. 

```
$ ./image-inspector -container 37017548dc46 -scan-type clamav -clam-socket /var/run/clamd.scan/clamd.sock 
2017/07/19 14:47:49 Extracting image  to /var/tmp/image-inspector-434280052
2017/07/19 14:47:51 clamav scan took 0s (1 problems found)
```
