### PR TITLE
Enable running multiple scans on an image

### DIFF
--- a/cmd/image-inspector.go
+++ b/cmd/image-inspector.go
@@ -10,6 +10,7 @@ import (
 	iiapi "github.com/openshift/image-inspector/pkg/api"
 	iicmd "github.com/openshift/image-inspector/pkg/cmd"
 	ii "github.com/openshift/image-inspector/pkg/inspector"
+	"github.com/openshift/image-inspector/pkg/util"
 )
 
 func main() {
@@ -25,7 +26,7 @@ func main() {
 	flag.Var(&inspectorOptions.DockerCfg, "dockercfg", "Location of the docker configuration files. May be specified more than once")
 	flag.StringVar(&inspectorOptions.Username, "username", inspectorOptions.Username, "username for authenticating with the docker registry")
 	flag.StringVar(&inspectorOptions.PasswordFile, "password-file", inspectorOptions.PasswordFile, "Location of a file that contains the password for authentication with the docker registry")
-	flag.StringVar(&inspectorOptions.ScanType, "scan-type", inspectorOptions.ScanType, fmt.Sprintf("The type of the scan to be done on the inspected image. Available scan types are: %v", iiapi.ScanOptions))
+	flag.Var(&inspectorOptions.ScanTypes, "scan-type", fmt.Sprintf("The type of the scan to be done on the inspected image. Available scan types are: %v", iiapi.ScanOptions))
 	flag.StringVar(&inspectorOptions.ScanResultsDir, "scan-results-dir", inspectorOptions.ScanResultsDir, "The directory that will contain the results of the scan")
 	flag.BoolVar(&inspectorOptions.OpenScapHTML, "openscap-html-report", inspectorOptions.OpenScapHTML, "Generate an OpenScap HTML report in addition to the ARF formatted report")
 	flag.StringVar(&inspectorOptions.CVEUrlPath, "cve-url", inspectorOptions.CVEUrlPath, "An alternative URL source for CVE files")
@@ -36,6 +37,8 @@ func main() {
 	flag.StringVar(&inspectorOptions.PullPolicy, "pull-policy", inspectorOptions.PullPolicy, fmt.Sprintf("Pull policy, default is %s, options are: %v", iiapi.PullIfNotPresent, iiapi.PullPolicyOptions))
 
 	flag.Parse()
+
+	inspectorOptions.ScanTypes = util.Unique(inspectorOptions.ScanTypes)
 
 	if inspectorOptions.AuthTokenFile != "" {
 		authToken, err := ioutil.ReadFile(inspectorOptions.AuthTokenFile)

--- a/pkg/cmd/types_test.go
+++ b/pkg/cmd/types_test.go
@@ -26,13 +26,13 @@ func TestValidate(t *testing.T) {
 	goodConfigUsername.Image = "image"
 	goodConfigUsername.Username = "username"
 	goodConfigUsername.PasswordFile = "types.go"
-	goodConfigUsername.ScanType = "clamav"
+	goodConfigUsername.ScanTypes = MultiStringVar{"clamav"}
 	goodConfigUsername.ClamSocket = "clamav"
 
 	goodConfigWithDockerCfg := NewDefaultImageInspectorOptions()
 	goodConfigWithDockerCfg.Image = "image"
 	goodConfigWithDockerCfg.DockerCfg.Set("types.go")
-	goodConfigWithDockerCfg.ScanType = "openscap"
+	goodConfigWithDockerCfg.ScanTypes = MultiStringVar{"openscap"}
 
 	noScanTypeAndDir := NewDefaultImageInspectorOptions()
 	noScanTypeAndDir.Image = "image"
@@ -40,18 +40,18 @@ func TestValidate(t *testing.T) {
 
 	goodScanOptions := NewDefaultImageInspectorOptions()
 	goodScanOptions.Image = "image"
-	goodScanOptions.ScanType = "openscap"
+	goodScanOptions.ScanTypes = MultiStringVar{"openscap"}
 	goodScanOptions.ScanResultsDir = "."
 	goodScanOptions.OpenScapHTML = true
 
 	notADirResScan := NewDefaultImageInspectorOptions()
 	notADirResScan.Image = "image"
-	notADirResScan.ScanType = "openscap"
+	notADirResScan.ScanTypes = MultiStringVar{"openscap"}
 	notADirResScan.ScanResultsDir = "types_test.go"
 
 	noSuchScanType := NewDefaultImageInspectorOptions()
 	noSuchScanType.Image = "image"
-	noSuchScanType.ScanType = "nosuchscantype"
+	noSuchScanType.ScanTypes = MultiStringVar{"nosuchscantype"}
 	noSuchScanType.ScanResultsDir = "."
 
 	noSuchFileDockercfg := NewDefaultImageInspectorOptions()
@@ -65,7 +65,7 @@ func TestValidate(t *testing.T) {
 	badScanOptionsHTMLWrongScan := NewDefaultImageInspectorOptions()
 	badScanOptionsHTMLWrongScan.Image = "image"
 	badScanOptionsHTMLWrongScan.OpenScapHTML = true
-	badScanOptionsHTMLWrongScan.ScanType = "nosuchscantype"
+	badScanOptionsHTMLWrongScan.ScanTypes = MultiStringVar{"nosuchscantype"}
 
 	noSuchPullPolicy := NewDefaultImageInspectorOptions()
 	noSuchPullPolicy.Image = "image"
@@ -110,7 +110,7 @@ func TestValidate(t *testing.T) {
 
 	// for 100% coverage we need to test MultiStringVar::String
 	goodConfigWithDockerCfg.DockerCfg.Set("types_test.go")
-	if len(goodConfigWithDockerCfg.DockerCfg.Values) != 2 {
+	if len(goodConfigWithDockerCfg.DockerCfg) != 2 {
 		t.Errorf("MultiStringVar Set didn't add to the lenght of Values")
 	}
 	st := goodConfigWithDockerCfg.DockerCfg.String()

--- a/pkg/imageserver/types.go
+++ b/pkg/imageserver/types.go
@@ -33,7 +33,7 @@ type ImageServerOptions struct {
 	// ContentURL is the relative url of the content.  ex /api/v1/content/
 	ContentURL string
 	// ScanType is the type of the scan that was done on the inspected image
-	ScanType string
+	ScanTypes []string
 	// ScanReportURL is the url to publish the scan report
 	ScanReportURL string
 	// HTMLScanReport wether or not to publish an HTML scan report

--- a/pkg/imageserver/webdav.go
+++ b/pkg/imageserver/webdav.go
@@ -102,7 +102,7 @@ func (s *webdavImageServer) GetHandler(meta *iiapi.InspectorMetadata,
 	})
 
 	mux.HandleFunc(s.opts.ScanReportURL, func(w http.ResponseWriter, r *http.Request) {
-		if s.opts.ScanType != "" && meta.OpenSCAP.Status == iiapi.StatusSuccess {
+		if len(s.opts.ScanTypes) > 0 && meta.OpenSCAP.Status == iiapi.StatusSuccess {
 			w.Write(scanReport)
 		} else {
 			if meta.OpenSCAP.Status == iiapi.StatusError {
@@ -115,7 +115,7 @@ func (s *webdavImageServer) GetHandler(meta *iiapi.InspectorMetadata,
 	})
 
 	mux.HandleFunc(s.opts.HTMLScanReportURL, func(w http.ResponseWriter, r *http.Request) {
-		if s.opts.ScanType != "" && meta.OpenSCAP.Status == iiapi.StatusSuccess && s.opts.HTMLScanReport {
+		if len(s.opts.ScanTypes) > 0 && meta.OpenSCAP.Status == iiapi.StatusSuccess && s.opts.HTMLScanReport {
 			w.Write(htmlScanReport)
 		} else {
 			if meta.OpenSCAP.Status == iiapi.StatusError {

--- a/pkg/imageserver/webdav_test.go
+++ b/pkg/imageserver/webdav_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Webdav", func() {
 			APIVersions:       apiVersions,
 			MetadataURL:       metadataPath,
 			ContentURL:        contentPath,
-			ScanType:          scanType,
+			ScanTypes:         []string{scanType},
 			ScanReportURL:     openscapReportPath,
 			HTMLScanReport:    true,
 			HTMLScanReportURL: openScapHTMLReportPath,

--- a/pkg/inspector/image-inspector_integration_test.go
+++ b/pkg/inspector/image-inspector_integration_test.go
@@ -34,7 +34,7 @@ var _ = Describe("ImageInspector", func() {
 		opts.Serve = serve
 		opts.AuthToken = validToken
 		opts.Image = "registry.access.redhat.com/rhel7:latest"
-		opts.ScanType = "openscap"
+		opts.ScanTypes = iicmd.MultiStringVar{"openscap"}
 		opts.DstPath, err = ioutil.TempDir("", "")
 		Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/inspector/image-inspector_test.go
+++ b/pkg/inspector/image-inspector_test.go
@@ -61,7 +61,7 @@ func TestGetAuthConfigs(t *testing.T) {
 	goodNoAuth := iicmd.NewDefaultImageInspectorOptions()
 
 	goodTwoDockerCfg := iicmd.NewDefaultImageInspectorOptions()
-	goodTwoDockerCfg.DockerCfg.Values = []string{"test/dockercfg1", "test/dockercfg2"}
+	goodTwoDockerCfg.DockerCfg = iicmd.MultiStringVar{"test/dockercfg1", "test/dockercfg2"}
 
 	goodUserAndPass := iicmd.NewDefaultImageInspectorOptions()
 	goodUserAndPass.Username = "erez"
@@ -72,13 +72,13 @@ func TestGetAuthConfigs(t *testing.T) {
 	badUserAndPass.PasswordFile = "test/nosuchfile"
 
 	badDockerCfgMissing := iicmd.NewDefaultImageInspectorOptions()
-	badDockerCfgMissing.DockerCfg.Values = []string{"test/dockercfg1", "test/nosuchfile"}
+	badDockerCfgMissing.DockerCfg = iicmd.MultiStringVar{"test/dockercfg1", "test/nosuchfile"}
 
 	badDockerCfgWrong := iicmd.NewDefaultImageInspectorOptions()
-	badDockerCfgWrong.DockerCfg.Values = []string{"test/dockercfg1", "test/passwordFile1"}
+	badDockerCfgWrong.DockerCfg = iicmd.MultiStringVar{"test/dockercfg1", "test/passwordFile1"}
 
 	badDockerCfgNoAuth := iicmd.NewDefaultImageInspectorOptions()
-	badDockerCfgNoAuth.DockerCfg.Values = []string{"test/dockercfg1", "test/dockercfg3"}
+	badDockerCfgNoAuth.DockerCfg = iicmd.MultiStringVar{"test/dockercfg1", "test/dockercfg3"}
 
 	tests := map[string]struct {
 		opts          *iicmd.ImageInspectorOptions

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -22,3 +22,13 @@ func StringInList(s string, l []string) bool {
 	}
 	return false
 }
+
+func Unique(a []string) []string {
+	b := []string{}
+	for _, v := range a {
+		if !StringInList(v, b) {
+			b = append(b, v)
+		}
+	}
+	return b
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -30,3 +30,17 @@ func TestStringInList(t *testing.T) {
 		t.Errorf("Is not found in the list")
 	}
 }
+
+func TestUnique(t *testing.T) {
+	a := []string{"one", "two", "three", "three"}
+	actual := Unique(a)
+	expected := []string{"one", "two", "three"}
+	if len(actual) != len(expected) {
+		t.Errorf("expected %v to have len %v",  actual, len(expected))
+	}
+	for i := range actual {
+		if actual[i] != expected[i] {
+			t.Errorf("expected %v to equal %v", actual[i], expected[i])
+		}
+	}
+}


### PR DESCRIPTION
What this PR does:
- [x] Make `--scan-type=...` a repeatable CLI flag. Each unique scan type provided will trigger a scan of that type. Repeated types will be ignored.
- [x] Enable *no* scan-types (no scan will be run,  image conent will still be served on `/api/v1/content`