### PR TITLE
Change current working directory after chroot

### DIFF
--- a/pkg/imageserver/webdav.go
+++ b/pkg/imageserver/webdav.go
@@ -69,6 +69,9 @@ func (s *webdavImageServer) GetHandler(meta *iiapi.InspectorMetadata,
 		if err := syscall.Chroot(ImageServeURL); err != nil {
 			return nil, fmt.Errorf("Unable to chroot into %s: %v\n", ImageServeURL, err)
 		}
+		if err := syscall.Chdir("/"); err != nil {
+			return nil, fmt.Errorf("Unable to change directory into new root: %v\n", err)
+		}
 		servePath = chrootServePath
 	} else {
 		log.Printf("!!!WARNING!!! It is insecure to serve the image content without changing")


### PR DESCRIPTION
The `syscall.Chroot` does  not change the current working directory, so that after the call '.' can be outside the tree rooted at '/'. In particular, the user can escape from a "chroot jail".

See `chroot(2)`, `openat(2)` manpages.