### PR TITLE
serve the status of image acquiring

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -93,6 +93,8 @@ var (
 
 // InspectorMetadata is the metadata type with information about image-inspector's operation
 type InspectorMetadata struct {
+	ImageAcquireError string // error from aquiring the image
+
 	docker.Image // Metadata about the inspected image
 
 	// OpenSCAP describes the state of the OpenSCAP scan

--- a/pkg/inspector/image-inspector.go
+++ b/pkg/inspector/image-inspector.go
@@ -391,7 +391,7 @@ func (i *defaultImageInspector) pullImage(client DockerRuntimeClient) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("Unable to pull docker image: %v\n", err)
+	return fmt.Errorf("Unable to pull docker image: %v", err)
 }
 
 // createAndExtractImage creates a docker container based on the option's image with containerName.
@@ -647,6 +647,9 @@ func (i *defaultImageInspector) acquireImage(client DockerRuntimeClient) (error,
 
 		if i.opts.ScanContainerChanges {
 			filterInclude, err = i.getContainerChanges(client, meta)
+			if err != nil {
+				return err, docker.Image{}, "", "", nil
+			}
 		}
 
 		i.opts.DstPath = fmt.Sprintf("/proc/%d/root/", meta.Container.State.Pid)

--- a/pkg/inspector/image-inspector_test.go
+++ b/pkg/inspector/image-inspector_test.go
@@ -335,7 +335,7 @@ func TestAcquireImage(t *testing.T) {
 			client: mockDockerRuntimeClientAllSuccess{}},
 	} {
 		ii := &defaultImageInspector{v.opts, iiapi.InspectorMetadata{}, nil}
-		err, _, _, _, _ := ii.acquireImage(v.client)
+		err, _, _ := ii.acquireImage(v.client)
 		if v.shouldFail {
 			if err == nil {
 				t.Errorf("%s should have failed but it didn't", k)

--- a/pkg/inspector/image-inspector_test.go
+++ b/pkg/inspector/image-inspector_test.go
@@ -19,7 +19,7 @@ func TestAcquiringInInspect(t *testing.T) {
 		expectedAcqErr string
 	}{
 		"Scanner fails on scan": {ii: defaultImageInspector{opts: iicmd.ImageInspectorOptions{URI: "No such file", Serve: ""}},
-			shouldFail:     false,
+			shouldFail:     true,
 			expectedAcqErr: "invalid endpoint",
 		},
 	} {
@@ -76,7 +76,7 @@ func TestGetAuthConfigs(t *testing.T) {
 	}
 
 	for k, v := range tests {
-		ii := &defaultImageInspector{*v.opts, iiapi.InspectorMetadata{}, nil}
+		ii := &defaultImageInspector{*v.opts, iiapi.InspectorMetadata{}, nil, scanOutputs{}}
 		auths, err := ii.getAuthConfigs()
 		if !v.shouldFail {
 			if err != nil {
@@ -284,7 +284,7 @@ func TestPullImage(t *testing.T) {
 		"With instant pull success client": {shouldFail: false,
 			client: mockRuntimeClientPullSuccess{}},
 	} {
-		ii := &defaultImageInspector{iicmd.ImageInspectorOptions{Image: "NoSuchImage!"}, iiapi.InspectorMetadata{}, nil}
+		ii := &defaultImageInspector{iicmd.ImageInspectorOptions{Image: "NoSuchImage!"}, iiapi.InspectorMetadata{}, nil, scanOutputs{}}
 		err := ii.pullImage(v.client)
 		if v.shouldFail {
 			if err == nil {
@@ -334,8 +334,8 @@ func TestAcquireImage(t *testing.T) {
 		"Success with running Container": {opts: fromContainer, shouldFail: false,
 			client: mockDockerRuntimeClientAllSuccess{}},
 	} {
-		ii := &defaultImageInspector{v.opts, iiapi.InspectorMetadata{}, nil}
-		err, _, _ := ii.acquireImage(v.client)
+		ii := &defaultImageInspector{v.opts, iiapi.InspectorMetadata{}, nil, scanOutputs{}}
+		err, _ := ii.acquireImage(v.client)
 		if v.shouldFail {
 			if err == nil {
 				t.Errorf("%s should have failed but it didn't", k)


### PR DESCRIPTION
When image-inspector fails to acquire an image and is in the serve mode it fails to serve this status and just exists. I consider this a bug.
To fix I added two fields to the metadata status: ImageAcquireSuccess, ImageAcquireError to report that status.