### PR TITLE
serve the raw results in /results endpoint

### DIFF
--- a/pkg/imageserver/webdav.go
+++ b/pkg/imageserver/webdav.go
@@ -101,6 +101,15 @@ func (s *webdavImageServer) GetHandler(meta *iiapi.InspectorMetadata,
 		w.Write(body)
 	})
 
+	mux.HandleFunc(s.opts.ResultAPIUrlPath, func(w http.ResponseWriter, r *http.Request) {
+		resultJSON, err := json.MarshalIndent(results, "", "  ")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Write(resultJSON)
+	})
+
 	mux.HandleFunc(s.opts.ScanReportURL, func(w http.ResponseWriter, r *http.Request) {
 		if s.opts.ScanType != "" && meta.OpenSCAP.Status == iiapi.StatusSuccess {
 			w.Write(scanReport)

--- a/pkg/imageserver/webdav_test.go
+++ b/pkg/imageserver/webdav_test.go
@@ -18,6 +18,7 @@ import (
 const (
 	versionTag             = "v1"
 	healthzPath            = "/healthz"
+	resultPath             = "/results"
 	apiPrefix              = "/api"
 	contentPath            = apiPrefix + "/" + versionTag + "/content/"
 	metadataPath           = apiPrefix + "/" + versionTag + "/metadata"
@@ -59,6 +60,7 @@ var _ = Describe("Webdav", func() {
 			MetadataURL:       metadataPath,
 			ContentURL:        contentPath,
 			ScanType:          scanType,
+			ResultAPIUrlPath:  resultPath,
 			ScanReportURL:     openscapReportPath,
 			HTMLScanReport:    true,
 			HTMLScanReportURL: openScapHTMLReportPath,


### PR DESCRIPTION
This will serve the raw results from the scanners in the `/results` endpoint.

It seems that it was meant to be that way a long time ago as `ResultAPIUrlPath` already exists and is set with the default value of `/results`.

The output from an OpenSCAP scan will look like this after json formatting (`python -m json.tool`):
[results_output_example_openscap.txt](https://github.com/openshift/image-inspector/files/1573009/results_output_example_openscap.txt)

This seems especially helpful for the clamav scanner which doesn't produce reports.

Aims to fix #84 
