### PR TITLE
Fix-88 Starts building image-inspector image at registry.centos.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM registry.centos.org/centos/centos:7
 MAINTAINER      Federico Simoncelli <fsimonce@redhat.com>
 
 RUN yum update -y && \

--- a/cccp.yml
+++ b/cccp.yml
@@ -1,0 +1,1 @@
+job-id: image-inspector


### PR DESCRIPTION
  Fixes #88

  Adds a file cccp.yml with `job-id: image-inspect`, needed to build
  at registry.centos.org