### PR TITLE
Rearrange Parameters in readOpenSCAPReports()

### DIFF
--- a/pkg/openscap/openscap.go
+++ b/pkg/openscap/openscap.go
@@ -250,7 +250,7 @@ func (s *defaultOSCAPScanner) readOpenSCAPReports() ([]byte, []byte, error) {
 		if err != nil {
 			return empty, empty, err
 		}
-		return htmlResults, arfResults, nil
+		return arfResults, htmlResults, nil
 	}
 	return arfResults, empty, nil
 }


### PR DESCRIPTION
I believe that the parameters in `readOpenSCAPReports()` has been improperly placed. When running the `image-inspector` command with `--openscap-html-report` specified, it currently tries to run `xmldom.ParseXML(string(report))` (line 264) on the resulting html file. This results in a parse error that I was able to resolve by switching the order of the two parameters on line 253