### PR TITLE
Fix XML Parse Result Order

### DIFF
--- a/pkg/openscap/openscap.go
+++ b/pkg/openscap/openscap.go
@@ -259,7 +259,7 @@ func (s *defaultOSCAPScanner) readOpenSCAPReports() ([]byte, []byte, error) {
 		if err != nil {
 			return empty, empty, err
 		}
-		return htmlResults, arfResults, nil
+		return arfResults, htmlResults, nil
 	}
 	return arfResults, empty, nil
 }


### PR DESCRIPTION
Fix a bug in which `--openscap-html-report` breaks the parsing of ARF files.