### PR TITLE
Fix yum install golang and buggy go version check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ MAINTAINER      Federico Simoncelli <fsimonce@redhat.com>
 # EPEL repo needed for golang on CentOS 7.
 RUN yum update -y && \
     yum install -y epel-release && \
-    yum install -y golang openscap-scanner git && \
+    yum install -y golang && \
+    yum install -y openscap-scanner && \
+    yum install -y git && \
     yum clean all
 
 COPY .  /go/src/github.com/openshift/image-inspector

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM registry.centos.org/centos/centos:7
 MAINTAINER      Federico Simoncelli <fsimonce@redhat.com>
 
+# EPEL repo needed for golang on CentOS 7.
 RUN yum update -y && \
+    yum install -y epel-release && \
     yum install -y golang openscap-scanner git && \
     yum clean all
 

--- a/Dockerfile.travis
+++ b/Dockerfile.travis
@@ -1,8 +1,7 @@
 FROM travis/image-inspector-base
-RUN yum install -y \
-    git \
-    which \
-    make
+RUN yum install -y git && \
+    yum install -y which && \
+    yum install -y make
 ENV GOPATH=/go
 COPY . /go/src/github.com/openshift/image-inspector
 WORKDIR /go/src/github.com/openshift/image-inspector

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -51,7 +51,8 @@ EOF
   if [[ "${TRAVIS:-}" != "true" ]]; then
     local go_version
     go_version=($(go version))
-    if [[ "${go_version[2]}" < "go1.5" ]]; then
+    minimum_go_version=go1.5.0
+    if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
       cat <<EOF
 
 Detected Go version: ${go_version[*]}.


### PR DESCRIPTION
@nimrodshn @bagnaram @jhernand please review.  This should make travis green again.

Not sure how `yum install golang` ever worked, perhaps some older centos 7 did have it without EPEL ¯\\\_(ツ)\_/¯

go version check had same bug as in k8s and openshift — string comparison treated go1.10 < 1.2.
Fixed using not pretty but well-debugged command from k8s https://github.com/kubernetes/kubernetes/pull/58207 (and not openshift whose fix is still buggy https://github.com/openshift/origin/pull/18807#discussion_r254295165)

P.S. I'm sorely tempted to tear out most of the hack/ directory.  It's based on k8s & openshift hack/ but really overkill here.
<details>
Currently `.travis.yml` calls `.travis.sh` which is pointless wrapper for 3 docker commands which use 2 containers to call Makefile which is pointless wrapper for tons of complex scripts which at the end of it do:

1. go get 3 things (godep ginkgo gomega)
2. go fmt (but only active with go1.5)
3. go build cmd/image-inspector.go

And well, the buggy go version test I'm fixing here.
Only the 2 hack/test-* scripts are maybe non-trivial.  One runs go test, and test/end-to-end/e2e.sh really needs some bash functions.
</details>
But I'm resisting that temptation for now :smile: